### PR TITLE
Formatted jokes.json with straight apostrophes

### DIFF
--- a/admin_panel.py
+++ b/admin_panel.py
@@ -1,0 +1,287 @@
+import tkinter as tk
+from tkinter import ttk, messagebox, colorchooser
+from joke_utils import remove_duplicate_jokes # Import the deduplication utility
+import copy # For deepcopying the list
+
+def create_admin_panel(app_root, jokes_list, reactions_data, theme_settings, save_jokes_func):
+    """
+    Creates and displays the Admin Panel.
+
+    Args:
+        app_root: The main application root window.
+        jokes_list: The list of joke dictionaries.
+        reactions_data: The dictionary of joke reactions.
+        theme_settings: The dictionary containing current theme settings.
+        save_jokes_func: Callback function to save the jokes list.
+    """
+    admin = tk.Toplevel(app_root)
+    admin.title("Admin Panel")
+    admin.geometry("750x550") # Slightly larger for better padding
+    admin.configure(padx=10, pady=10) # Add root padding to admin panel
+
+    # Notebook style will be inherited from main app's style.configure("TNotebook.Tab", ...)
+    notebook = ttk.Notebook(admin)
+    notebook.pack(fill="both", expand=True, padx=5, pady=5)
+
+    # Standard font for tk widgets in admin panel if not covered by ttk styles
+    admin_font = ('Helvetica', 10)
+
+    # --- Joke Editor Tab ---
+    editor_frame = ttk.Frame(notebook, padding=(10,10)) # Use ttk.Frame and add padding
+    notebook.add(editor_frame, text="Edit Jokes")
+
+    per_page = 50
+    current_page = tk.IntVar(value=0)
+
+    # Use a frame to hold listbox and its scrollbar
+    listbox_frame = ttk.Frame(editor_frame) # Use ttk.Frame
+    listbox_frame.pack(side="left", fill="both", expand=True, pady=5, padx=5)
+
+    listbox_scrollbar = ttk.Scrollbar(listbox_frame, orient="vertical")
+    listbox_scrollbar.pack(side="right", fill="y")
+
+    listbox = tk.Listbox(listbox_frame, height=15, yscrollcommand=listbox_scrollbar.set, font=admin_font)
+    listbox.pack(side="left", fill="both", expand=True)
+    listbox_scrollbar.config(command=listbox.yview)
+    
+    edit_controls_frame = ttk.Frame(editor_frame) # Use ttk.Frame
+    edit_controls_frame.pack(side="right", fill="y", padx=(10,5), pady=5)
+
+    cat_entry = ttk.Entry(edit_controls_frame, font=admin_font, width=30) # Use ttk.Entry
+    cat_entry.pack(pady=5, fill="x")
+
+    def load_page():
+        listbox.delete(0, tk.END)
+        start = current_page.get() * per_page
+        for i, joke in enumerate(jokes_list[start:start+per_page]):
+            # Ensure 'text' key exists, provide default if not (robustness)
+            listbox.insert(tk.END, joke.get("text", "N/A")[:80])
+
+
+    def update_categories():
+        idx_tuple = listbox.curselection()
+        if not idx_tuple:
+            return
+        # listbox.curselection() returns a tuple, e.g., (0,)
+        actual_idx = idx_tuple[0] 
+        joke_idx_in_list = current_page.get() * per_page + actual_idx
+        
+        if 0 <= joke_idx_in_list < len(jokes_list):
+            cats = [c.strip() for c in cat_entry.get().split(",") if c.strip()]
+            jokes_list[joke_idx_in_list]["categories"] = cats
+            save_jokes_func(jokes_list)
+            # No need to call load_page() if listbox text doesn't change, but categories do.
+            # However, if joke text could change or for simplicity, reloading is fine.
+            # To refresh categories in view if selected joke is the one edited:
+            on_select(None) # Refresh category entry
+        else:
+            messagebox.showerror("Error", "Selected joke index is out of range.")
+
+
+    def on_select(event): # event can be None if called manually
+        idx_tuple = listbox.curselection()
+        if not idx_tuple:
+            # If called manually with event=None and nothing is selected, clear cat_entry
+            cat_entry.delete(0, tk.END)
+            return
+        
+        actual_idx = idx_tuple[0]
+        joke_idx_in_list = current_page.get() * per_page + actual_idx
+        
+        if 0 <= joke_idx_in_list < len(jokes_list):
+            cat_entry.delete(0, tk.END)
+            cat_entry.insert(0, ", ".join(jokes_list[joke_idx_in_list].get("categories", [])))
+        else:
+            # This case should ideally not happen if listbox and jokes_list are in sync
+            cat_entry.delete(0, tk.END)
+            messagebox.showwarning("Warning", "Could not find selected joke data.")
+
+
+    listbox.bind("<<ListboxSelect>>", on_select)
+    ttk.Button(edit_controls_frame, text="Update Categories", command=update_categories, style="TButton").pack(pady=10) # Use ttk.Button
+    
+    page_buttons_frame = ttk.Frame(edit_controls_frame) # Use ttk.Frame, place within controls
+    page_buttons_frame.pack(side="bottom", pady=10) 
+    ttk.Button(page_buttons_frame, text="Prev", command=lambda: (current_page.set(max(0, current_page.get() - 1)), load_page()), style="TButton").pack(side="left", padx=5)
+    ttk.Button(page_buttons_frame, text="Next", command=lambda: (current_page.set(min(current_page.get() + 1, (len(jokes_list)-1)//per_page )), load_page()), style="TButton").pack(side="left", padx=5)
+    
+    load_page() # Initial load
+
+    # --- Category Count Tab ---
+    count_frame = ttk.Frame(notebook, padding=(10,10)) # Use ttk.Frame and add padding
+    notebook.add(count_frame, text="Category Counts")
+
+    chart_canvas = tk.Canvas(count_frame, bg="white") # bg likely overridden by theme if this was ttk.Canvas
+    chart_canvas.pack(side="left", fill="both", expand=True, padx=5, pady=5)
+
+    scrollbar = ttk.Scrollbar(count_frame, orient="vertical", command=chart_canvas.yview)
+    scrollbar.pack(side="right", fill="y")
+    chart_canvas.configure(yscrollcommand=scrollbar.set)
+
+    def draw_category_chart(event=None):
+        chart_canvas.delete("all")
+        counts = {}
+        for joke in jokes_list:
+            for cat in joke.get("categories", []): # Ensure categories exist
+                counts[cat] = counts.get(cat, 0) + 1
+
+        if not counts:
+            chart_canvas.create_text(10, 10, anchor="nw", text="No categories to display.", font=admin_font)
+            return
+
+        sorted_counts = sorted(counts.items(), key=lambda item: item[1], reverse=True)
+        bar_height = 20
+        bar_padding = 5
+        label_area_width = 140 # Increased for potentially longer category names
+        text_offset_x = 10
+        
+        canvas_width = chart_canvas.winfo_width()
+        if canvas_width <= 1: canvas_width = chart_canvas.master.winfo_width() if chart_canvas.master.winfo_width() > 1 else 600
+        
+        max_bar_width = canvas_width - label_area_width - text_offset_x - 40 # Increased padding for count
+        if max_bar_width < 50: max_bar_width = 50
+        max_val_count = sorted_counts[0][1] if sorted_counts else 1
+
+        for i, (category, count) in enumerate(sorted_counts):
+            y_position = i * (bar_height + bar_padding) + bar_padding
+            # Category Name
+            chart_canvas.create_text(text_offset_x, y_position + bar_height / 2, text=category, anchor="w", font=admin_font, width=label_area_width - text_offset_x - 5)
+            bar_start_x = label_area_width
+            bar_length = (count / max_val_count) * max_bar_width if max_val_count > 0 else 0
+            chart_canvas.create_rectangle(bar_start_x, y_position, bar_start_x + bar_length, y_position + bar_height, fill="skyblue", outline="grey") # Softer outline
+            # Count Label next to bar
+            chart_canvas.create_text(bar_start_x + bar_length + 5, y_position + bar_height / 2, text=str(count), anchor="w", font=admin_font)
+        
+        total_chart_height = len(sorted_counts) * (bar_height + bar_padding) + bar_padding
+        chart_canvas.config(scrollregion=(0, 0, canvas_width, total_chart_height))
+
+    refresh_button = ttk.Button(count_frame, text="Refresh Category Counts", command=draw_category_chart, style="TButton") # Use ttk.Button
+    refresh_button.pack(pady=10, side="bottom")
+    
+    # Bindings for category chart
+    # Delay initial draw slightly to allow canvas to size
+    admin.after(100, draw_category_chart) # Draw after admin window is surely mapped and sized
+    chart_canvas.bind("<Configure>", draw_category_chart)
+    # Redraw when tab becomes visible
+    def on_tab_selected(event):
+        selected_tab_index = notebook.index(notebook.select())
+        category_count_tab_index = notebook.tabs().index(count_frame) # Get the actual index of count_frame
+        if selected_tab_index == category_count_tab_index:
+            admin.after(50, draw_category_chart) # Small delay to ensure canvas is ready
+    notebook.bind("<<NotebookTabChanged>>", on_tab_selected)
+
+
+    # --- Theme Tab ---
+    theme_editor_frame = ttk.Frame(notebook, padding=(10,10)) # Use ttk.Frame and add padding
+    notebook.add(theme_editor_frame, text="Theme")
+
+    # Note: The theme change logic here is basic. A full theme application would involve
+    # updating ttk styles or having the main app handle theme changes more globally.
+    def change_admin_theme_color(): 
+        color = colorchooser.askcolor(title="Choose Background Color for Admin Panel")[1]
+        if color:
+            admin.configure(bg=color) 
+            # This is a superficial change for the admin window itself.
+            # ttk widgets within are styled by the ttk theme.
+            # To change their actual style, one would need to update ttk.Style configurations.
+            theme_settings["bg"] = color # Update the shared theme dictionary
+
+    ttk.Button(theme_editor_frame, text="Change Admin Panel Background", command=change_admin_theme_color, style="TButton").pack(pady=10) # Use ttk.Button
+
+    # --- Emoji Reactions Tab ---
+    reactions_display_frame = ttk.Frame(notebook, padding=(10,10)) # Use ttk.Frame and add padding
+    notebook.add(reactions_display_frame, text="Emoji Reactions")
+
+    reactions_text_frame = ttk.Frame(reactions_display_frame) # Use ttk.Frame
+    reactions_text_frame.pack(fill="both", expand=True, padx=5, pady=5)
+
+    reactions_scrollbar = ttk.Scrollbar(reactions_text_frame, orient="vertical")
+    reactions_scrollbar.pack(side="right", fill="y")
+
+    reactions_text_widget = tk.Text(reactions_text_frame, wrap="word", yscrollcommand=reactions_scrollbar.set, height=10, font=admin_font)
+    reactions_text_widget.pack(side="left", fill="both", expand=True)
+    reactions_scrollbar.config(command=reactions_text_widget.yview)
+
+    
+    sorted_reacts = sorted(reactions_data.items(), key=lambda x: x[1].get("Funny", 0), reverse=True)
+    summary_text = ""
+    if not sorted_reacts:
+        summary_text = "No reactions yet."
+    else:
+        for joke_text_val, reacts in sorted_reacts:
+             # Ensure 'text' key exists for joke, provide default if not
+            joke_display_text = joke_text_val[:50] + "..." if len(joke_text_val) > 50 else joke_text_val
+            summary_text += f"{joke_display_text}\n"
+            summary_text += f"  😆 Funny: {reacts.get('Funny', 0)} | 🤔 Huh?: {reacts.get('Confused', 0)} | 🙄 So Bad: {reacts.get('Bad', 0)}\n\n"
+    
+    reactions_text_widget.insert(tk.END, summary_text)
+    reactions_text_widget.config(state="disabled") # Make it read-only
+
+    # --- Utilities Tab ---
+    utilities_frame = ttk.Frame(notebook, padding=(10,10)) # Use ttk.Frame and add padding
+    notebook.add(utilities_frame, text="Utilities")
+
+    fuzzy_threshold_var = tk.DoubleVar(value=0.9) # Keep as is, for tk.Entry primarily
+
+    def run_deduplication():
+        # Make a copy to avoid modifying the original list if the user cancels or if no changes
+        original_jokes_copy = copy.deepcopy(jokes_list)
+        
+        try:
+            threshold = fuzzy_threshold_var.get()
+        except tk.TclError:
+            messagebox.showerror("Error", "Invalid threshold value. Please enter a number (e.g., 0.9).")
+            return
+
+        if not (0.0 <= threshold <= 1.0):
+            messagebox.showerror("Error", "Fuzzy threshold must be between 0.0 and 1.0.")
+            return
+
+        cleaned_jokes_list = remove_duplicate_jokes(original_jokes_copy, fuzzy_threshold=threshold)
+        
+        num_original = len(jokes_list) # Compare with the live list's current state
+        num_cleaned = len(cleaned_jokes_list)
+        num_removed = num_original - num_cleaned
+
+        if num_removed > 0:
+            # Update the main jokes_list in place
+            jokes_list[:] = cleaned_jokes_list 
+            save_jokes_func(jokes_list) # Persist changes
+            messagebox.showinfo("Deduplication Complete", 
+                                f"{num_removed} duplicate joke(s) removed (or merged).\n"
+                                f"The joke list has been updated and saved.\n"
+                                f"New joke count: {num_cleaned}")
+            
+            # Adjust current_page in joke editor if it's now out of bounds
+            max_page = (len(jokes_list) - 1) // per_page
+            if current_page.get() > max_page:
+                current_page.set(max(0, max_page)) # Ensure current_page is not negative if list becomes empty
+
+            load_page() # Refresh the joke editor listbox on the "Edit Jokes" tab
+            # Also, if category chart is visible, it should be refreshed.
+            # Calling draw_category_chart directly might try to draw if tab isn't visible.
+            # This is okay, or could be tied to tab visibility.
+            draw_category_chart() 
+        else:
+            messagebox.showinfo("Deduplication Complete", "No duplicate jokes found based on the current threshold.")
+
+    dedup_controls_frame = ttk.Frame(utilities_frame) # Use ttk.Frame
+    dedup_controls_frame.pack(pady=10, padx=10, fill="x")
+    
+    ttk.Label(dedup_controls_frame, text="Fuzzy Match Threshold (0.0-1.0):", font=admin_font).pack(side="left", padx=(0,5)) # Use ttk.Label
+    # Using tk.Entry for DoubleVar, or switch to ttk.Entry and manage var differently if needed for pure ttk.
+    # ttk.Entry usually works fine with DoubleVar.
+    threshold_entry = ttk.Entry(dedup_controls_frame, textvariable=fuzzy_threshold_var, width=5, font=admin_font) # Use ttk.Entry
+    threshold_entry.pack(side="left", padx=5)
+    ttk.Button(dedup_controls_frame, text="Remove Duplicate Jokes", command=run_deduplication, style="TButton").pack(side="left", padx=5) # Use ttk.Button
+    
+    # Ensure the admin window is brought to the front and focused
+    admin.transient(app_root) # Keep admin window on top of main window
+    admin.grab_set()         # Modal behavior: disable other windows until this one is closed
+    admin.focus_set()        # Focus on the admin window
+    app_root.wait_window(admin) # Wait until admin window is closed
+
+# Example of how this might be called from dadjoke.py:
+# from admin_panel import create_admin_panel
+# ...
+# tk.Button(root, text="Admin Panel", command=lambda: create_admin_panel(root, jokes, reactions, theme, save_jokes)).pack()

--- a/dadjoke.py
+++ b/dadjoke.py
@@ -12,26 +12,28 @@ def speak(text):
     engine.say(text)
     engine.runAndWait()
 
-# Load jokes from file
-def load_jokes(filename="dadjokeslist.txt"): #Update with link to your joke file
+# Load jokes from JSON file
+def load_jokes(filename="jokes.json"):
     jokes = []
     if not os.path.exists(filename):
+        # Create an empty jokes.json if it doesn't exist
+        with open(filename, "w") as f:
+            json.dump([], f)
         return jokes
-    with open(filename, "r") as f:
-        for line in f:
-            parts = line.strip().split("%%")
-            text = parts[0].strip()
-            categories = [p.strip() for p in parts[1:]]
-            jokes.append({"text": text, "categories": categories})
+    try:
+        with open(filename, "r") as f:
+            jokes = json.load(f)
+    except json.JSONDecodeError:
+        # Handle cases where the file is empty or malformed
+        # You might want to log this error or create a default empty list
+        with open(filename, "w") as f: # Overwrite/create with empty list
+            json.dump([], f)
+        return [] # Return empty list if decode error
     return jokes
 
-def save_jokes(jokes, filename="dadjokeslist.txt"): #Update with link to your joke file
+def save_jokes(jokes, filename="jokes.json"):
     with open(filename, "w") as f:
-        for joke in jokes:
-            line = joke["text"]
-            for cat in joke["categories"]:
-                line += f" %%{cat}"
-            f.write(line + "\n")
+        json.dump(jokes, f, indent=2)
 
 # Load and save reactions
 def load_reactions(filename="joke_reactions.json"):
@@ -211,18 +213,42 @@ def get_all_categories():
 # --- Main App ---
 root = tk.Tk()
 root.title("Dad Joke Generator")
-root.configure(bg=theme["bg"])
+
+# Apply some root padding
+root.configure(bg=theme["bg"], padx=10, pady=10)
+
+# --- TTK Styling ---
+style = ttk.Style()
+try:
+    style.theme_use('clam') # A modern theme
+except tk.TclError:
+    try:
+        style.theme_use('alt') # Fallback
+    except tk.TclError:
+        style.theme_use('default') # Last resort
+
+# Base font for all ttk widgets (tk widgets might need separate config or inherit)
+style.configure('.', font=('Helvetica', 10))
+
+# Custom style for TButton for consistent padding
+style.configure("TButton", padding=5)
+
+# Custom style for TNotebook tabs
+style.configure("TNotebook.Tab", padding=(10, 5), font=('Helvetica', 10, 'bold'))
+
 
 joke_text = tk.StringVar()
 cat_label_var = tk.StringVar()
 
 category_var = tk.StringVar()
-category_dropdown = ttk.Combobox(root, textvariable=category_var)
+# Using ttk.Combobox - should pick up style
+category_dropdown = ttk.Combobox(root, textvariable=category_var, font=('Helvetica', 10)) 
 category_dropdown['values'] = get_all_categories()
-category_dropdown.pack(pady=5)
+category_dropdown.pack(pady=10, padx=5, fill="x")
 
-search_entry = tk.Entry(root)
-search_entry.pack(pady=3)
+# Using tk.Entry, font might need to be set if not inherited, or switch to ttk.Entry
+search_entry = tk.Entry(root, font=('Helvetica', 10))
+search_entry.pack(pady=5, padx=5, fill="x")
 
 def search_jokes():
     term = search_entry.get().lower()
@@ -232,23 +258,42 @@ def search_jokes():
     else:
         messagebox.showinfo("Search", "No jokes matched your search.")
 
-tk.Button(root, text="Search", command=search_jokes, bg=theme["button"]).pack(pady=2)
+# Using ttk.Button for themed buttons where custom bg isn't paramount
+ttk.Button(root, text="Search", command=search_jokes, style="TButton").pack(pady=5, padx=5, fill="x")
 
-joke_label = tk.Label(root, textvariable=joke_text, wraplength=400, bg=theme["bg"], fg=theme["fg"])
-joke_label.pack(pady=10)
+# tk.Label - will use theme["bg"], theme["fg"]. Font should be inherited from root or set.
+joke_label = tk.Label(root, textvariable=joke_text, wraplength=400, bg=theme["bg"], fg=theme["fg"], font=('Helvetica', 12))
+joke_label.pack(pady=10, padx=5)
 
-cat_label = tk.Label(root, textvariable=cat_label_var, bg=theme["bg"], fg=theme["fg"])
-cat_label.pack()
+cat_label = tk.Label(root, textvariable=cat_label_var, bg=theme["bg"], fg=theme["fg"], font=('Helvetica', 9))
+cat_label.pack(pady=5, padx=5)
 
-tk.Button(root, text="Random Joke", command=lambda: show_joke(get_random_joke()), bg=theme["button"]).pack(pady=3)
-tk.Button(root, text="Seasonal Joke", command=lambda: show_joke(get_seasonal_joke()), bg=theme["button"]).pack(pady=3)
-tk.Button(root, text="Get Joke from Category", command=lambda: show_joke(get_joke_by_category(category_var.get())), bg=theme["button"]).pack(pady=3)
+# Button frame for main action buttons
+button_action_frame = ttk.Frame(root) # Use ttk.Frame
+button_action_frame.pack(pady=10, padx=5, fill="x")
 
-reaction_frame = tk.Frame(root, bg=theme["bg"])
-reaction_frame.pack(pady=5)
-tk.Button(reaction_frame, text="😆 Funny!", command=lambda: react_to_joke("Funny"), bg="lightgreen").pack(side="left", padx=5)
-tk.Button(reaction_frame, text="🤔 Huh?", command=lambda: react_to_joke("Confused"), bg="lightyellow").pack(side="left", padx=5)
-tk.Button(reaction_frame, text="🙄 So Bad", command=lambda: react_to_joke("Bad"), bg="lightcoral").pack(side="left", padx=5)
+# Using ttk.Button for these as well, custom theme["button"] color might not apply directly with all ttk themes.
+# If specific colors are essential, tk.Button might be kept, or style ttk.Button further.
+# For now, let's use ttk.Button and rely on the TButton style for padding.
+# The 'bg=theme["button"]' will be less effective on ttk.Button for some themes.
+# We are prioritizing ttk styling for this pass.
+col_weight = 1
+button_action_frame.columnconfigure(0, weight=col_weight)
+button_action_frame.columnconfigure(1, weight=col_weight)
+button_action_frame.columnconfigure(2, weight=col_weight)
+
+ttk.Button(button_action_frame, text="Random Joke", command=lambda: show_joke(get_random_joke()), style="TButton").grid(row=0, column=0, pady=5, padx=2, sticky="ew")
+ttk.Button(button_action_frame, text="Seasonal Joke", command=lambda: show_joke(get_seasonal_joke()), style="TButton").grid(row=0, column=1, pady=5, padx=2, sticky="ew")
+ttk.Button(button_action_frame, text="Get Joke from Category", command=lambda: show_joke(get_joke_by_category(category_var.get())), style="TButton").grid(row=0, column=2, pady=5, padx=2, sticky="ew")
+
+
+# Reaction buttons: these have specific colors. Keep as tk.Button for now.
+reaction_frame = tk.Frame(root, bg=theme["bg"]) # This is a tk.Frame
+reaction_frame.pack(pady=10, padx=5)
+tk.Button(reaction_frame, text="😆 Funny!", command=lambda: react_to_joke("Funny"), bg="lightgreen", font=('Helvetica', 10), relief=tk.FLAT, padx=5, pady=2).pack(side="left", padx=5)
+tk.Button(reaction_frame, text="🤔 Huh?", command=lambda: react_to_joke("Confused"), bg="lightyellow", font=('Helvetica', 10), relief=tk.FLAT, padx=5, pady=2).pack(side="left", padx=5)
+tk.Button(reaction_frame, text="🙄 So Bad", command=lambda: react_to_joke("Bad"), bg="lightcoral", font=('Helvetica', 10), relief=tk.FLAT, padx=5, pady=2).pack(side="left", padx=5)
+
 
 def show_favorites():
     if not favorites:
@@ -257,10 +302,20 @@ def show_favorites():
     fav_text = "\n\n".join(j["text"] for j in favorites)
     messagebox.showinfo("Favorite Jokes", fav_text)
 
-tk.Button(root, text="View Favorites", command=show_favorites, bg=theme["button"]).pack(pady=3)
+# Management buttons frame
+button_mgmt_frame = ttk.Frame(root) # Use ttk.Frame
+button_mgmt_frame.pack(pady=10, padx=5, fill="x")
+button_mgmt_frame.columnconfigure(0, weight=1) # Allow buttons to expand
+button_mgmt_frame.columnconfigure(1, weight=1)
 
-style_frame = tk.Frame(root, bg=theme["bg"])
-style_frame.pack(pady=5)
+
+ttk.Button(button_mgmt_frame, text="View Favorites", command=show_favorites, style="TButton").grid(row=0, column=0, pady=5, padx=2, sticky="ew")
+ttk.Button(button_mgmt_frame, text="Admin Panel", command=lambda: create_admin_panel(root, jokes, reactions, theme, save_jokes), style="TButton").grid(row=0, column=1, pady=5, padx=2, sticky="ew")
+
+
+# Style frame for theme dropdown - use ttk.Frame
+style_controls_frame = ttk.Frame(root) # Renamed from style_frame
+style_controls_frame.pack(pady=10, padx=5)
 
 def apply_theme(choice):
     themes = {
@@ -273,8 +328,13 @@ def apply_theme(choice):
         update_theme(*themes[choice])
 
 theme_var = tk.StringVar(value="Default")
-theme_menu = ttk.OptionMenu(style_frame, theme_var, "Default", *["Default", "Space", "Jungle", "Candyland"], command=apply_theme)
-theme_menu.pack()
+# ttk.OptionMenu - should pick up style
+theme_menu = ttk.OptionMenu(style_controls_frame, theme_var, "Default", "Default", "Space", "Jungle", "Candyland", command=apply_theme)
+theme_menu.pack(pady=5, padx=5)
+
+
+# Import the admin panel creation function
+from admin_panel import create_admin_panel
 
 def on_exit():
     goodbye_joke = get_joke_by_category("goodbye")
@@ -282,129 +342,18 @@ def on_exit():
         speak(goodbye_joke["text"])
     root.destroy()
 
-def open_admin_panel():
-    admin = tk.Toplevel(root)
-    admin.title("Admin Panel")
-    admin.geometry("700x500")
-
-    notebook = ttk.Notebook(admin)
-    notebook.pack(fill="both", expand=True)
-
-    # --- Joke Editor Tab ---
-    editor_frame = tk.Frame(notebook)
-    notebook.add(editor_frame, text="Edit Jokes")
-
-    per_page = 50
-    current_page = tk.IntVar(value=0)
-
-    listbox = tk.Listbox(editor_frame, height=20)
-    listbox.pack(side="left", fill="y")
-
-    edit_frame = tk.Frame(editor_frame)
-    edit_frame.pack(side="right", fill="both", expand=True)
-
-    cat_entry = tk.Entry(edit_frame)
-    cat_entry.pack(pady=5)
-
-    def load_page():
-        listbox.delete(0, tk.END)
-        start = current_page.get() * per_page
-        for i, joke in enumerate(jokes[start:start+per_page]):
-            listbox.insert(tk.END, joke["text"][:80])
-
-    def update_categories():
-        idx = listbox.curselection()
-        if not idx:
-            return
-        joke_idx = current_page.get() * per_page + idx[0]
-        cats = [c.strip() for c in cat_entry.get().split(",") if c.strip()]
-        jokes[joke_idx]["categories"] = cats
-        save_jokes(jokes)
-        load_page()
-
-    def on_select(event):
-        idx = listbox.curselection()
-        if not idx:
-            return
-        joke_idx = current_page.get() * per_page + idx[0]
-        cat_entry.delete(0, tk.END)
-        cat_entry.insert(0, ", ".join(jokes[joke_idx]["categories"]))
-
-    listbox.bind("<<ListboxSelect>>", on_select)
-    tk.Button(edit_frame, text="Update Categories", command=update_categories).pack(pady=2)
-    tk.Button(editor_frame, text="Prev", command=lambda: (current_page.set(max(0, current_page.get() - 1)), load_page())).pack()
-    tk.Button(editor_frame, text="Next", command=lambda: (current_page.set(current_page.get() + 1), load_page())).pack()
-    load_page()
-
-    # --- Category Count Tab ---
-    count_frame = tk.Frame(notebook)
-    notebook.add(count_frame, text="Category Counts")
-
-    def show_category_counts():
-        counts = {}
-        for j in jokes:
-            for cat in j["categories"]:
-                counts[cat] = counts.get(cat, 0) + 1
-        if not counts:
-            messagebox.showinfo("No Categories", "There are no categories to count.")
-            return
-
-        counts_win = tk.Toplevel(root)
-        counts_win.title("Category Counts")
-        counts_win.geometry("400x400")
-
-        canvas = tk.Canvas(counts_win)
-        scrollbar = ttk.Scrollbar(counts_win, orient="vertical", command=canvas.yview)
-        scroll_frame = tk.Frame(canvas)
-
-        scroll_frame.bind(
-            "<Configure>",
-            lambda e: canvas.configure(scrollregion=canvas.bbox("all"))
-        )
-
-        canvas.create_window((0, 0), window=scroll_frame, anchor="nw")
-        canvas.configure(yscrollcommand=scrollbar.set)
-
-        canvas.pack(side="left", fill="both", expand=True)
-        scrollbar.pack(side="right", fill="y")
-
-        for cat, count in sorted(counts.items()):
-            tk.Label(scroll_frame, text=f"{cat}: {count}", anchor="w").pack(anchor="w", padx=10)
-
-    tk.Button(count_frame, text="Show Category Counts", command=show_category_counts).pack(pady=10)
-
-    # --- Theme Tab ---
-    theme_frame = tk.Frame(notebook)
-    notebook.add(theme_frame, text="Theme")
-
-    def change_theme():
-        color = colorchooser.askcolor(title="Choose Background Color")[1]
-        if color:
-            theme["bg"] = color
-            root.configure(bg=color)
-            for widget in root.winfo_children():
-                widget.configure(bg=color)
-
-    tk.Button(theme_frame, text="Change Background Color", command=change_theme).pack(pady=10)
-
-    # --- Emoji Reactions Tab ---
-    reaction_frame = tk.Frame(notebook)
-    notebook.add(reaction_frame, text="Emoji Reactions")
-
-    sorted_reacts = sorted(reactions.items(), key=lambda x: x[1].get("Funny", 0), reverse=True)
-    summary = ""
-    for joke, reacts in sorted_reacts:
-        summary += f"\n{joke[:50]}...\n  Funny: {reacts.get('Funny', 0)} | Huh: {reacts.get('Confused', 0)} | Bad: {reacts.get('Bad', 0)}\n"
-    tk.Label(reaction_frame, text=summary or "No reactions yet.", justify="left", anchor="w").pack(padx=10, pady=10, fill="both", expand=True)
-
-tk.Button(root, text="Admin Panel", command=open_admin_panel, bg=theme["button"]).pack(pady=3)
-tk.Button(root, text="Close", command=on_exit, bg=theme["button"], fg=theme["fg"]).pack(pady=3) # Modified close button
+# Close button - tk.Button to allow specific theme["fg"] color.
+# Or, create a specific ttk style for it if that's preferred.
+tk.Button(root, text="Close", command=on_exit, bg=theme.get("button", "lightgrey"), fg=theme.get("fg", "black"), font=('Helvetica', 10, 'bold'), relief=tk.FLAT, padx=10, pady=5).pack(pady=20, padx=5)
 
 
 
 
 
 # --- UI Functions ---
+# Make sure messagebox is available if show_joke uses it and is not moved.
+# from tkinter import messagebox # Already imported at the top
+
 def show_joke(joke):
     if not joke:
         messagebox.showinfo("Oops!", "No joke found for this category!")
@@ -436,13 +385,34 @@ def update_theme(bg, fg, button):
     root.configure(bg=bg)
     for widget in root.winfo_children():
         try:
-            widget.configure(bg=bg, fg=fg)
-        except:
+            # For ttk widgets, changing bg/fg might be theme-dependent.
+            # tk widgets will respond to this.
+            if isinstance(widget, (ttk.Frame, ttk.Label, ttk.Button, ttk.Combobox, ttk.OptionMenu)):
+                 # For ttk widgets, rely more on the ttk theme and style configurations.
+                 # Overriding 'background' and 'foreground' directly might not always work as expected
+                 # or might make them look inconsistent with the theme.
+                 # However, if 'theme' dict is meant to override, this is where it would happen.
+                 # We might need to create specific ttk styles for themed elements if this is not enough.
+                pass # Let ttk styles handle these mostly.
+            widget.configure(bg=bg) # Apply bg to all for consistency if possible
+            if not isinstance(widget, (ttk.Combobox, ttk.Entry)): # Avoid changing fg for entry type widgets if it makes text unreadable
+                 widget.configure(fg=fg)
+
+        except tk.TclError: # Some widgets might not have bg/fg or specific ones like Combobox list
             pass
+    # Ensure main window background is updated
+    root.configure(bg=bg)
+    # Update specific tk.Labels that use theme colors
+    joke_label.config(bg=bg, fg=fg)
+    cat_label.config(bg=bg, fg=fg)
+    # Update reaction_frame and its tk.Buttons (as they are tk based)
+    reaction_frame.config(bg=bg)
+    # Note: ttk.Buttons in button_action_frame and button_mgmt_frame will NOT be affected by theme['button'] color here.
+    # tk.Button for "Close" will be.
 
 def apply_theme(choice):
     themes = {
-        "Default": ("#f0f0f0", "black", "lightblue"),
+        "Default": ("#f0f0f0", "black", "lightblue"), # bg, fg, button_bg
         "Space": ("#1a1a2e", "white", "#0f3460"),
         "Jungle": ("#dff0d8", "darkgreen", "#4caf50"),
         "Candyland": ("#ffe6f0", "deeppink", "#ff99cc")

--- a/dadjokelist.txt
+++ b/dadjokelist.txt
@@ -1,1 +1,0 @@
-What is an cow's favorite activity? Going to the mooovies. %%Animal

--- a/joke_utils.py
+++ b/joke_utils.py
@@ -1,0 +1,60 @@
+import difflib
+import re
+
+def normalize_text(text):
+    """Lowercase and remove punctuation from text."""
+    text = text.lower()
+    text = re.sub(r'[^\w\s]', '', text) # Remove punctuation
+    text = re.sub(r'\s+', ' ', text).strip() # Normalize whitespace
+    return text
+
+def remove_duplicate_jokes(jokes_list, fuzzy_threshold=0.9):
+    """
+    Removes duplicate jokes from a list, merging categories.
+
+    Args:
+        jokes_list: A list of joke dictionaries. 
+                    Each dict is expected to have 'id', 'text', and 'categories'.
+        fuzzy_threshold: Similarity threshold for fuzzy matching (0.0 to 1.0).
+
+    Returns:
+        A new list of unique joke dictionaries with merged categories.
+    """
+    if not jokes_list:
+        return []
+
+    unique_jokes = []
+    # Store normalized text of jokes already added to unique_jokes to avoid re-normalizing
+    normalized_unique_texts = [] 
+
+    for joke in jokes_list:
+        if not isinstance(joke, dict) or "text" not in joke or "categories" not in joke or "id" not in joke:
+            # Skip malformed joke entries, or handle as an error
+            print(f"Skipping malformed joke: {joke}")
+            continue
+
+        normalized_current_joke_text = normalize_text(joke["text"])
+        is_duplicate = False
+        
+        for i, unique_joke in enumerate(unique_jokes):
+            # Compare with normalized text of already added unique jokes
+            # No need to re-normalize unique_joke["text"] if we store them
+            
+            # Using normalized_unique_texts[i] which should correspond to unique_joke
+            similarity = difflib.SequenceMatcher(None, normalized_current_joke_text, normalized_unique_texts[i]).ratio()
+            
+            if similarity >= fuzzy_threshold:
+                is_duplicate = True
+                # Merge categories: add categories from current joke to the existing unique joke
+                # Ensure categories in the unique_joke remain unique
+                existing_categories = set(unique_joke["categories"])
+                for cat in joke["categories"]:
+                    existing_categories.add(cat)
+                unique_jokes[i]["categories"] = sorted(list(existing_categories)) # Keep it sorted
+                break 
+                
+        if not is_duplicate:
+            unique_jokes.append(joke.copy()) # Add a copy to avoid modifying original list items directly
+            normalized_unique_texts.append(normalized_current_joke_text) # Store its normalized form
+
+    return unique_jokes

--- a/jokes.json
+++ b/jokes.json
@@ -1,0 +1,7821 @@
+[
+    {
+        "id": 1,
+        "text": "I'm afraid for the calendar. Its days are numbered.",
+        "categories": []
+    },
+    {
+        "id": 2,
+        "text": "Why do fathers take an extra pair of socks when they go golfing?In case they get a hole in one!",
+        "categories": []
+    },
+    {
+        "id": 3,
+        "text": "Singing in the shower is fun until you get soap in your mouth. Then it's a soap opera.",
+        "categories": []
+    },
+    {
+        "id": 4,
+        "text": "What do a tick and the Eiffel Tower have in common?They're both Paris sites.",
+        "categories": []
+    },
+    {
+        "id": 5,
+        "text": "What do you call a fish wearing a bowtie? Sofishticated.",
+        "categories": []
+    },
+    {
+        "id": 6,
+        "text": "If April showers bring May flowers, what do May flowers bring? Pilgrims.",
+        "categories": []
+    },
+    {
+        "id": 7,
+        "text": "What do you call a factory that makes okay products? A satisfactory.",
+        "categories": []
+    },
+    {
+        "id": 8,
+        "text": "Have you heard about the chocolate record player? It sounds pretty sweet.",
+        "categories": []
+    },
+    {
+        "id": 9,
+        "text": "I only know 25 letters of the alphabet. I don't know y.",
+        "categories": []
+    },
+    {
+        "id": 10,
+        "text": "What did one wall say to the other? I'll meet you at the corner.",
+        "categories": []
+    },
+    {
+        "id": 11,
+        "text": "Where do fruits go on vacation?Pear-is!",
+        "categories": []
+    },
+    {
+        "id": 12,
+        "text": "What's the best thing about Switzerland? I don't know, but the flag is a big plus.",
+        "categories": []
+    },
+    {
+        "id": 13,
+        "text": "What does a sprinter eat before a race? Nothing, they fast!",
+        "categories": []
+    },
+    {
+        "id": 14,
+        "text": "What has more letters than the alphabet? The post office!",
+        "categories": []
+    },
+    {
+        "id": 15,
+        "text": "What do you call a poor Santa Claus? St. Nickel-less.",
+        "categories": [
+            "Christmas"
+        ]
+    },
+    {
+        "id": 16,
+        "text": "How do you get a squirrel to like you? Act like a nut.",
+        "categories": []
+    },
+    {
+        "id": 17,
+        "text": "Why don't eggs tell jokes? They'd crack each other up.",
+        "categories": [
+            "Food"
+        ]
+    },
+    {
+        "id": 18,
+        "text": "I don't trust stairs. They're always up to something.",
+        "categories": []
+    },
+    {
+        "id": 19,
+        "text": "What do you call someone with no body and no nose? Nobody knows.",
+        "categories": []
+    },
+    {
+        "id": 20,
+        "text": "Did you hear the rumor about butter? Well, I'm not going to spread it!",
+        "categories": [
+            "Food"
+        ]
+    },
+    {
+        "id": 21,
+        "text": "Why couldn't the bicycle stand up by itself? It was two tired.",
+        "categories": []
+    },
+    {
+        "id": 22,
+        "text": "What did one hat say to the other? Stay here! I'm going on ahead.",
+        "categories": []
+    },
+    {
+        "id": 23,
+        "text": "This graveyard looks overcrowded. People must be dying to get in.",
+        "categories": []
+    },
+    {
+        "id": 24,
+        "text": "What does a lemon say when it answers the phone? Yellow!",
+        "categories": [
+            "Food"
+        ]
+    },
+    {
+        "id": 25,
+        "text": "Why can't a nose be 12 inches long? Because then it would be a foot.",
+        "categories": []
+    },
+    {
+        "id": 26,
+        "text": "What kind of car does an egg drive? A yolkswagen.",
+        "categories": [
+            "Food"
+        ]
+    },
+    {
+        "id": 27,
+        "text": "How do you make 7 even? Take away the s.",
+        "categories": []
+    },
+    {
+        "id": 28,
+        "text": "How many tickles does it take to make an octopus laugh? Ten tickles.",
+        "categories": []
+    },
+    {
+        "id": 29,
+        "text": "Why don't eggs tell jokes? They'd crack each other up.",
+        "categories": [
+            "Food"
+        ]
+    },
+    {
+        "id": 30,
+        "text": "What do you call an angry carrot? A steamed veggie.",
+        "categories": [
+            "Food"
+        ]
+    },
+    {
+        "id": 31,
+        "text": "It takes guts to be an organ donor.",
+        "categories": []
+    },
+    {
+        "id": 32,
+        "text": "How do you make a tissue dance? You put a little boogie in it.",
+        "categories": []
+    },
+    {
+        "id": 33,
+        "text": "Why did the math book look so sad? Because of all of its problems!",
+        "categories": [
+            "School"
+        ]
+    },
+    {
+        "id": 34,
+        "text": "What do you call cheese that isn't yours? Nacho cheese.",
+        "categories": [
+            "Food"
+        ]
+    },
+    {
+        "id": 35,
+        "text": "How does a penguin build its house? Igloos it together.",
+        "categories": []
+    },
+    {
+        "id": 36,
+        "text": "What country's capital is growing the fastest? Ireland. Every day it's Dublin.",
+        "categories": []
+    },
+    {
+        "id": 37,
+        "text": "I'm on a seafood diet. I see food and I eat it.",
+        "categories": [
+            "Food"
+        ]
+    },
+    {
+        "id": 38,
+        "text": "Why did the scarecrow win an award? Because he was outstanding in his field.",
+        "categories": []
+    },
+    {
+        "id": 39,
+        "text": "I made a pencil with two erasers. It was pointless.",
+        "categories": []
+    },
+    {
+        "id": 40,
+        "text": "I'm reading a book about anti-gravity. It's impossible to put down!",
+        "categories": []
+    },
+    {
+        "id": 41,
+        "text": "Did you hear about the guy who invented the knock-knock joke? He won the 'no-bell' prize.",
+        "categories": []
+    },
+    {
+        "id": 42,
+        "text": "I've got a great joke about construction, but I'm still working on it.",
+        "categories": []
+    },
+    {
+        "id": 43,
+        "text": "I used to hate facial hair...but then it grew on me.",
+        "categories": []
+    },
+    {
+        "id": 44,
+        "text": "I decided to sell my vacuum cleaner—it was just gathering dust!",
+        "categories": []
+    },
+    {
+        "id": 45,
+        "text": "You know, people say they pick their nose, but I feel like I was just born with mine.",
+        "categories": []
+    },
+    {
+        "id": 46,
+        "text": "What's brown and sticky? A stick.",
+        "categories": []
+    },
+    {
+        "id": 47,
+        "text": "What do you call an elephant that doesn't matter? An irrelephant.",
+        "categories": [
+            "Animal"
+        ]
+    },
+    {
+        "id": 48,
+        "text": "What do you get from a pampered cow? Spoiled milk.",
+        "categories": []
+    },
+    {
+        "id": 49,
+        "text": "If you see a crime at an Apple Store, does that make you an iWitness?",
+        "categories": []
+    },
+    {
+        "id": 50,
+        "text": "I was going to tell a time-traveling joke, but you guys didn't like it.",
+        "categories": []
+    },
+    {
+        "id": 51,
+        "text": "What do you call a fake noodle? An impasta.",
+        "categories": [
+            "Food"
+        ]
+    },
+    {
+        "id": 52,
+        "text": "What do you call a belt made of watches? A waist of time.",
+        "categories": []
+    },
+    {
+        "id": 53,
+        "text": "What do you call a pony with a sore throat? A little hoarse.",
+        "categories": [
+            "Animal"
+        ]
+    },
+    {
+        "id": 54,
+        "text": "Mountains aren't just funny. They're hill areas.",
+        "categories": []
+    },
+    {
+        "id": 55,
+        "text": "How much does it cost Santa to park his sleigh? Nothing, it's on the house.",
+        "categories": [
+            "Christmas"
+        ]
+    },
+    {
+        "id": 56,
+        "text": "What's a robot's favorite snack? Computer chips.",
+        "categories": [
+            "Food"
+        ]
+    },
+    {
+        "id": 57,
+        "text": "Why are piggy banks so wise? They're filled with common cents.",
+        "categories": []
+    },
+    {
+        "id": 58,
+        "text": "How do you get a good price on a sled? You have toboggan.",
+        "categories": [
+            "Winter"
+        ]
+    },
+    {
+        "id": 59,
+        "text": "Where do young trees go to learn? Elementree school",
+        "categories": [
+            "School"
+        ]
+    },
+    {
+        "id": 60,
+        "text": "Wanna hear a joke about paper? Never mind—it's tearable.",
+        "categories": []
+    },
+    {
+        "id": 61,
+        "text": "I could tell a joke about pizza, but it's a little cheesy.",
+        "categories": [
+            "Food"
+        ]
+    },
+    {
+        "id": 62,
+        "text": "Don't trust atoms. They make up everything!",
+        "categories": []
+    },
+    {
+        "id": 63,
+        "text": "When does a joke become a dad joke? When it becomes apparent.",
+        "categories": []
+    },
+    {
+        "id": 64,
+        "text": "I don't play soccer because I enjoy the sport. I'm just doing it for kicks!",
+        "categories": [
+            "Sports"
+        ]
+    },
+    {
+        "id": 65,
+        "text": "Which state has the most streets? Rhode Island.",
+        "categories": []
+    },
+    {
+        "id": 66,
+        "text": "Did you hear about the fire at the shoe factory? Unfortunately, many soles were lost.",
+        "categories": []
+    },
+    {
+        "id": 67,
+        "text": "What do you call a pig who knows how to use a knife? A pork chop.",
+        "categories": [
+            "Food"
+        ]
+    },
+    {
+        "id": 68,
+        "text": "Why did the pony ask for a glass of water? Because it was a little horse.",
+        "categories": [
+            "Animal"
+        ]
+    },
+    {
+        "id": 69,
+        "text": "How many apples can you grow on a tree? All of them.",
+        "categories": [
+            "Food"
+        ]
+    },
+    {
+        "id": 70,
+        "text": "What do kids play when they have nothing else to do? Bored games.",
+        "categories": []
+    },
+    {
+        "id": 71,
+        "text": "What kind of music do elves listen to? Wrap music.",
+        "categories": [
+            "Christmas"
+        ]
+    },
+    {
+        "id": 72,
+        "text": "What does cake and baseball have in common? They both need a batter.",
+        "categories": [
+            "Sports"
+        ]
+    },
+    {
+        "id": 73,
+        "text": "When does Friday come before Thursday? In the dictionary.",
+        "categories": []
+    },
+    {
+        "id": 74,
+        "text": "How can you tell if a pig is hot? It's bacon.",
+        "categories": [
+            "Food"
+        ]
+    },
+    {
+        "id": 75,
+        "text": "What do you call a rude cow? Beef jerky",
+        "categories": [
+            "Animal"
+        ]
+    },
+    {
+        "id": 76,
+        "text": "How do you get a squirrel's attention? Act like a nut.",
+        "categories": [
+            "Animal"
+        ]
+    },
+    {
+        "id": 77,
+        "text": "Did you hear about the cat that ate a lemon? Now it's a sour puss.",
+        "categories": [
+            "Animal"
+        ]
+    },
+    {
+        "id": 78,
+        "text": "What did one volcano say to the other? I lava you.",
+        "categories": []
+    },
+    {
+        "id": 79,
+        "text": "How do mice floss their teeth? With string cheese.",
+        "categories": [
+            "Animal"
+        ]
+    },
+    {
+        "id": 80,
+        "text": "How do you cook an alligator? With a croc-pot.",
+        "categories": [
+            "Animal"
+        ]
+    },
+    {
+        "id": 81,
+        "text": "What did the earthquake say when it was done? Sorry, my fault!",
+        "categories": []
+    },
+    {
+        "id": 82,
+        "text": "Why did the computer go to bed? It needed to crash.",
+        "categories": []
+    },
+    {
+        "id": 83,
+        "text": "What kind of bug can tell time? A clock-roach.",
+        "categories": [
+            "Animal"
+        ]
+    },
+    {
+        "id": 84,
+        "text": "What do you call a can opener that doesn't work? A can't opener.",
+        "categories": []
+    },
+    {
+        "id": 85,
+        "text": "What do pigs use to clean up? Hogwash.",
+        "categories": [
+            "Animal"
+        ]
+    },
+    {
+        "id": 86,
+        "text": "What's a pirate's favorite letter? You'd think it's the R, but it's really the C.",
+        "categories": [
+            "Pirate"
+        ]
+    },
+    {
+        "id": 87,
+        "text": "When is a door not a door? When it's ajar.",
+        "categories": []
+    },
+    {
+        "id": 88,
+        "text": "Did you hear about the broken guitar for sale? It comes with no strings attached.",
+        "categories": []
+    },
+    {
+        "id": 89,
+        "text": "Once I read a book about glue. I couldn't put it down.",
+        "categories": []
+    },
+    {
+        "id": 90,
+        "text": "What do you call a fish with no eyes? Fsh.",
+        "categories": [
+            "Animal"
+        ]
+    },
+    {
+        "id": 91,
+        "text": "What should you do if you meet a giant? Use big words.",
+        "categories": []
+    },
+    {
+        "id": 92,
+        "text": "What do you call a cow with two legs? Lean beef.",
+        "categories": [
+            "Animal"
+        ]
+    },
+    {
+        "id": 93,
+        "text": "What sits on the seabed and has anxiety? A nervous wreck.",
+        "categories": []
+    },
+    {
+        "id": 94,
+        "text": "What's the best air to breathe if you want to be rich? Millionaire.",
+        "categories": []
+    },
+    {
+        "id": 95,
+        "text": "Why did the girl toss a clock out the window? She wanted to see time fly.",
+        "categories": []
+    },
+    {
+        "id": 96,
+        "text": "Where do armies belong? In your sleeves.",
+        "categories": []
+    },
+    {
+        "id": 97,
+        "text": "Where did the king put his armies? In his sleevies!",
+        "categories": []
+    },
+    {
+        "id": 98,
+        "text": "What did one plate say to another plate? Tonight, dinner's on me.",
+        "categories": []
+    },
+    {
+        "id": 99,
+        "text": "What happens when doctors get frustrated? They lose their patients.",
+        "categories": []
+    },
+    {
+        "id": 100,
+        "text": "What do you call a bear with no teeth? A gummy bear.",
+        "categories": [
+            "Animal"
+        ]
+    },
+    {
+        "id": 101,
+        "text": "What invention allows us to see through walls? Windows.",
+        "categories": []
+    },
+    {
+        "id": 102,
+        "text": "What's orange and sounds like a parrot? A carrot.",
+        "categories": [
+            "Animal"
+        ]
+    },
+    {
+        "id": 103,
+        "text": "Why did the coach go to the bank? To get his quarter back.",
+        "categories": [
+            "Sports"
+        ]
+    },
+    {
+        "id": 104,
+        "text": "Why do nurses like red crayons? Sometimes they have to draw blood.",
+        "categories": []
+    },
+    {
+        "id": 105,
+        "text": "What kind of jewelry do rabbits wear? 14 carrot gold.",
+        "categories": [
+            "Animal"
+        ]
+    },
+    {
+        "id": 106,
+        "text": "Why can't the pirate learn the alphabet? Because he kept getting lost at C.",
+        "categories": [
+            "Pirate"
+        ]
+    },
+    {
+        "id": 107,
+        "text": "What do you call a cheese that isn't yours? Nacho cheese!",
+        "categories": [
+            "Food"
+        ]
+    },
+    {
+        "id": 108,
+        "text": "How do celebrities keep cool? They have many fans.",
+        "categories": []
+    },
+    {
+        "id": 109,
+        "text": "What did the janitor say when he jumped out of the closet? Supplies!",
+        "categories": []
+    },
+    {
+        "id": 110,
+        "text": "What's more unbelievable than a talking dog? A spelling bee.",
+        "categories": [
+            "Animal"
+        ]
+    },
+    {
+        "id": 111,
+        "text": "What do you call a cow with no legs? Ground beef.",
+        "categories": [
+            "Animal"
+        ]
+    },
+    {
+        "id": 112,
+        "text": "What do you call a happy cowboy? A jolly rancher.",
+        "categories": []
+    },
+    {
+        "id": 113,
+        "text": "Why shouldn't you trust trees? They seem shady.",
+        "categories": []
+    },
+    {
+        "id": 114,
+        "text": "How do you fix a broken tomato? With tomato paste.",
+        "categories": [
+            "Animal"
+        ]
+    },
+    {
+        "id": 115,
+        "text": "What kind of music scares balloons? Pop music.",
+        "categories": []
+    },
+    {
+        "id": 116,
+        "text": "Why did the orange stop halfway across the road? It ran out of juice.",
+        "categories": [
+            "%%cross",
+            "Animal",
+            "Road",
+            "The"
+        ]
+    },
+    {
+        "id": 117,
+        "text": "Why did the Oreo go to the dentist? It lost its filling.",
+        "categories": [
+            "Animal"
+        ]
+    },
+    {
+        "id": 118,
+        "text": "How do you get an astronaut's baby to stop crying? You rocket.",
+        "categories": []
+    },
+    {
+        "id": 119,
+        "text": "What do dogs and phones have in common? Both have collar ID.",
+        "categories": [
+            "Animal"
+        ]
+    },
+    {
+        "id": 120,
+        "text": "Why shouldn't you play poker in the jungle? Too many cheetahs.",
+        "categories": [
+            "Animal"
+        ]
+    },
+    {
+        "id": 121,
+        "text": "What sounds like a sneeze and is made of leather? A shoe.",
+        "categories": []
+    },
+    {
+        "id": 122,
+        "text": "How do you stop a bull from charging? You cancel its credit card.",
+        "categories": [
+            "Animal"
+        ]
+    },
+    {
+        "id": 123,
+        "text": "Why was the math book sad? It had too many problems.",
+        "categories": [
+            "School"
+        ]
+    },
+    {
+        "id": 124,
+        "text": "Why are fish so smart? Because they swim in schools.",
+        "categories": [
+            "School"
+        ]
+    },
+    {
+        "id": 125,
+        "text": "Why did the employee get fired from the keyboard factory? He wasn't putting in enough shifts.",
+        "categories": []
+    },
+    {
+        "id": 126,
+        "text": "Did you hear about the man who cut off his left leg? He's all right now.",
+        "categories": []
+    },
+    {
+        "id": 127,
+        "text": "Did you hear the one about the claustrophobic astronaut? He just needed a little space.",
+        "categories": []
+    },
+    {
+        "id": 128,
+        "text": "What kind of music should you listen to while fishing? Something catchy!",
+        "categories": []
+    },
+    {
+        "id": 129,
+        "text": "What do you call a girl in the middle of a tennis court? Annette.",
+        "categories": [
+            "Sports"
+        ]
+    },
+    {
+        "id": 130,
+        "text": "What did the ocean say to the beach? Nothing. It just waved.",
+        "categories": [
+            "Beach"
+        ]
+    },
+    {
+        "id": 131,
+        "text": "What did one wall say to the other? I'll meet you at the corner.",
+        "categories": []
+    },
+    {
+        "id": 132,
+        "text": "Why did the nose feel sad? It was always getting picked on.",
+        "categories": []
+    },
+    {
+        "id": 133,
+        "text": "Did you hear about the cold dinner? It was chili.",
+        "categories": [
+            "Food"
+        ]
+    },
+    {
+        "id": 134,
+        "text": "Why did the deer go to the dentist? It had buck teeth.",
+        "categories": [
+            "Animal"
+        ]
+    },
+    {
+        "id": 135,
+        "text": "Why can't you trust a balloon? It's full of hot air.",
+        "categories": []
+    },
+    {
+        "id": 136,
+        "text": "A cheese factory exploded in France. Da brie is everywhere!",
+        "categories": [
+            "Animal"
+        ]
+    },
+    {
+        "id": 137,
+        "text": "Not sure if you have noticed, but I love bad puns. That's just how eye roll.",
+        "categories": []
+    },
+    {
+        "id": 138,
+        "text": "Why did the banana go to the doctor? Because it wasn't peeling well.",
+        "categories": [
+            "Food"
+        ]
+    },
+    {
+        "id": 139,
+        "text": "Where does a sheep go to get a haircut? The baa baa shop.",
+        "categories": [
+            "Animal"
+        ]
+    },
+    {
+        "id": 140,
+        "text": "What did the mama cow say to the baby cow? It's pasture bed time.",
+        "categories": [
+            "Animal"
+        ]
+    },
+    {
+        "id": 141,
+        "text": "Why should you never use a dull pencil? Because it's pointless.",
+        "categories": []
+    },
+    {
+        "id": 142,
+        "text": "Why did the cookie go to the doctor? It was feeling crumby.",
+        "categories": [
+            "Food"
+        ]
+    },
+    {
+        "id": 143,
+        "text": "Where did the cat go after losing its tail? The retail store.",
+        "categories": [
+            "Animal"
+        ]
+    },
+    {
+        "id": 144,
+        "text": "Why don't eggs tell jokes? They'd crack each other up.",
+        "categories": [
+            "Food"
+        ]
+    },
+    {
+        "id": 145,
+        "text": "What kind of sandals do frogs wear? Open-toad.",
+        "categories": [
+            "Animal"
+        ]
+    },
+    {
+        "id": 146,
+        "text": "What do you call a herd of sheep falling down a hill? A lambslide.",
+        "categories": [
+            "Animal"
+        ]
+    },
+    {
+        "id": 147,
+        "text": "How do you organize a space party? You planet.",
+        "categories": []
+    },
+    {
+        "id": 148,
+        "text": "How many tickles does it take to make an octopus laugh? Ten tickles.",
+        "categories": [
+            "Animal"
+        ]
+    },
+    {
+        "id": 149,
+        "text": "What do you call a potato wearing glasses? A spec-tater.",
+        "categories": [
+            "Food"
+        ]
+    },
+    {
+        "id": 150,
+        "text": "What do you call a moose with no name? Anonymoose.",
+        "categories": [
+            "Food"
+        ]
+    },
+    {
+        "id": 151,
+        "text": "Why did the ram run over the cliff? He didn't see the ewe turn.",
+        "categories": [
+            "Animal"
+        ]
+    },
+    {
+        "id": 152,
+        "text": "Why did the picture go to jail? He was framed.",
+        "categories": []
+    },
+    {
+        "id": 153,
+        "text": "What is a calendar's favorite food? Dates.",
+        "categories": []
+    },
+    {
+        "id": 154,
+        "text": "Why was the football stadium cold? There were too many fans.",
+        "categories": [
+            "Sports"
+        ]
+    },
+    {
+        "id": 155,
+        "text": "Why do bananas wear sunscreen? Because they peel.",
+        "categories": [
+            "Food"
+        ]
+    },
+    {
+        "id": 156,
+        "text": "Why do bees have sticky hair? Because they use honey combs.",
+        "categories": [
+            "Animal"
+        ]
+    },
+    {
+        "id": 157,
+        "text": "Why did the watch go on vacation? To unwind.",
+        "categories": []
+    },
+    {
+        "id": 158,
+        "text": "How does a penguin build a house? Igloos it together.",
+        "categories": [
+            "Animal"
+        ]
+    },
+    {
+        "id": 159,
+        "text": "Why do melons have weddings? Because they cantaloupe.",
+        "categories": []
+    },
+    {
+        "id": 160,
+        "text": "Why did the computer get glasses? To improve its website.",
+        "categories": []
+    },
+    {
+        "id": 161,
+        "text": "What did the blanket say to the bed? I've got you covered.",
+        "categories": []
+    },
+    {
+        "id": 162,
+        "text": "What did the roof say to the shingle? The first one's on the house.",
+        "categories": []
+    },
+    {
+        "id": 163,
+        "text": "What do you call birds that stick together? Velcrows",
+        "categories": [
+            "Animal"
+        ]
+    },
+    {
+        "id": 164,
+        "text": "Why did the duck fall on the sidewalk? He tripped on a quack.",
+        "categories": [
+            "Animal"
+        ]
+    },
+    {
+        "id": 165,
+        "text": "How do birds learn to fly? They wing it.",
+        "categories": [
+            "Animal"
+        ]
+    },
+    {
+        "id": 166,
+        "text": "Did you hear about the walnut and cashew that threw a party? It was nuts.",
+        "categories": [
+            "Food"
+        ]
+    },
+    {
+        "id": 167,
+        "text": "Did the hear about the ice cream truck accident? It crashed on a rocky road.",
+        "categories": []
+    },
+    {
+        "id": 168,
+        "text": "What kind of bird works on a construction site? A crane.",
+        "categories": [
+            "Animal"
+        ]
+    },
+    {
+        "id": 169,
+        "text": "What did one elevator say to the other elevator? I think I'm coming down with something.",
+        "categories": []
+    },
+    {
+        "id": 170,
+        "text": "What did the hamburger name its baby? Patty.",
+        "categories": []
+    },
+    {
+        "id": 171,
+        "text": "What type of music do the planets enjoy? Neptunes.",
+        "categories": []
+    },
+    {
+        "id": 172,
+        "text": "Why did the phone wear glasses? Because it lost all its contacts.",
+        "categories": []
+    },
+    {
+        "id": 173,
+        "text": "Why do bakers work so hard? Because they knead dough.",
+        "categories": []
+    },
+    {
+        "id": 174,
+        "text": "Why are fish so easy to weigh? Because they have their own set of scales.",
+        "categories": []
+    },
+    {
+        "id": 175,
+        "text": "What do you call a priest that becomes a lawyer? A father-in-law.",
+        "categories": []
+    },
+    {
+        "id": 176,
+        "text": "What do you give a scientist with bad breath? Experi-mints.",
+        "categories": []
+    },
+    {
+        "id": 177,
+        "text": "What did Benjamin Franklin say when he discovered electricity? Nothing. He was too shocked.",
+        "categories": []
+    },
+    {
+        "id": 178,
+        "text": "What do you call a medieval lamp? A knight light.",
+        "categories": []
+    },
+    {
+        "id": 179,
+        "text": "What did one hat say to the other? You go on ahead.",
+        "categories": []
+    },
+    {
+        "id": 180,
+        "text": "Why did the frog take the bus to work? His car got toad.",
+        "categories": []
+    },
+    {
+        "id": 181,
+        "text": "What does an evil hen lay? Deviled eggs.",
+        "categories": []
+    },
+    {
+        "id": 182,
+        "text": "How can you tell the difference between a dog and tree? By their bark.",
+        "categories": []
+    },
+    {
+        "id": 183,
+        "text": "Why do dragons sleep during the day? Because they like to fight knights.",
+        "categories": []
+    },
+    {
+        "id": 184,
+        "text": "Why did the scarecrow win an award? It was outstanding in his field.",
+        "categories": []
+    },
+    {
+        "id": 185,
+        "text": "Did you hear about the 12-inch dog? It was a foot long.",
+        "categories": []
+    },
+    {
+        "id": 186,
+        "text": "Why did the baseball player get arrested? He stole third base.",
+        "categories": []
+    },
+    {
+        "id": 187,
+        "text": "What did one piece of tape say to the other? Let's stick together.",
+        "categories": []
+    },
+    {
+        "id": 188,
+        "text": "What's brown and sticky? A stick.",
+        "categories": []
+    },
+    {
+        "id": 189,
+        "text": "How does the rancher keep track of his cattle? With a cow-culator.",
+        "categories": []
+    },
+    {
+        "id": 190,
+        "text": "What do you call a shoe made out of a banana? A slipper.",
+        "categories": []
+    },
+    {
+        "id": 191,
+        "text": "How you fix a broken pumpkin? With a pumpkin patch.",
+        "categories": []
+    },
+    {
+        "id": 192,
+        "text": "Where do boats go when they're sick? To the dock.",
+        "categories": []
+    },
+    {
+        "id": 193,
+        "text": "Can February March? No, but April May!",
+        "categories": []
+    },
+    {
+        "id": 194,
+        "text": "What do you call a fibbing cat? A lion.",
+        "categories": []
+    },
+    {
+        "id": 195,
+        "text": "Did you hear the rumor about butter? Well, I'm not going to go spreading it!",
+        "categories": []
+    },
+    {
+        "id": 196,
+        "text": "Where do you learn to make ice cream? Sundae school.",
+        "categories": []
+    },
+    {
+        "id": 197,
+        "text": "What's a scarecrow's favorite fruit? Straw-berries",
+        "categories": []
+    },
+    {
+        "id": 198,
+        "text": "Where do burgers go dancing? At the meatball.",
+        "categories": []
+    },
+    {
+        "id": 199,
+        "text": "What time do ducks wake up? At the quack of dawn.",
+        "categories": []
+    },
+    {
+        "id": 200,
+        "text": "Why was the broom late? It over-swept.",
+        "categories": []
+    },
+    {
+        "id": 201,
+        "text": "What kind of tree fits in your hand? A palm tree.",
+        "categories": []
+    },
+    {
+        "id": 202,
+        "text": "Where do books hide when they're afraid? Under their covers.",
+        "categories": []
+    },
+    {
+        "id": 203,
+        "text": "How do trees get on the internet? They log in.",
+        "categories": []
+    },
+    {
+        "id": 204,
+        "text": "What does a painter do when he gets cold? Puts on another coat.",
+        "categories": []
+    },
+    {
+        "id": 205,
+        "text": "What did the calculator say to the pencil? You can count on me.",
+        "categories": []
+    },
+    {
+        "id": 206,
+        "text": "What has four wheels and flies? A garbage truck.",
+        "categories": []
+    },
+    {
+        "id": 207,
+        "text": "What do you call two ducks and a cow? Quackers and milk.",
+        "categories": []
+    },
+    {
+        "id": 208,
+        "text": "What do cows like to read? Cattle-logs.",
+        "categories": []
+    },
+    {
+        "id": 209,
+        "text": "How did the farmer fix his torn overalls? With a cabbage patch.",
+        "categories": []
+    },
+    {
+        "id": 210,
+        "text": "How much money does a skunk have? Just one scent.",
+        "categories": []
+    },
+    {
+        "id": 211,
+        "text": "What do you get when you cross an elephant and a fish? Swimming trunks.",
+        "categories": []
+    },
+    {
+        "id": 212,
+        "text": "What kind of cereal do leprechauns eat? Lucky Charms.",
+        "categories": []
+    },
+    {
+        "id": 213,
+        "text": "What do you call recently-married spiders? Newly-webs.",
+        "categories": []
+    },
+    {
+        "id": 214,
+        "text": "Where do crayons go on vacation? Color-ado.",
+        "categories": []
+    },
+    {
+        "id": 215,
+        "text": "What do you get when you cross a Smurf and a cow? Blue cheese.",
+        "categories": []
+    },
+    {
+        "id": 216,
+        "text": "What happens when ice cream gets angry? It has a meltdown.",
+        "categories": []
+    },
+    {
+        "id": 217,
+        "text": "What do you call a locomotive carrying bubble gum? A chew chew train.",
+        "categories": []
+    },
+    {
+        "id": 218,
+        "text": "How do you get a mouse to smile? Say cheese.",
+        "categories": []
+    },
+    {
+        "id": 219,
+        "text": "Why couldn't the bike stand up on its own? It was too tired.",
+        "categories": []
+    },
+    {
+        "id": 220,
+        "text": "What do you call a sheep that knows karate? A lamb chop.",
+        "categories": []
+    },
+    {
+        "id": 221,
+        "text": "Why did the snowman buy a bag of carrots? He wanted to pick his nose.",
+        "categories": []
+    },
+    {
+        "id": 222,
+        "text": "What did the Dalmatian say after dinner? That hit the spot.",
+        "categories": []
+    },
+    {
+        "id": 223,
+        "text": "How do you know when a bike is thinking? You can see its wheels turning.",
+        "categories": []
+    },
+    {
+        "id": 224,
+        "text": "What does a librarian use to go fishing? A bookworm.",
+        "categories": []
+    },
+    {
+        "id": 225,
+        "text": "What did one leaf say to the other? I'm falling for you.",
+        "categories": []
+    },
+    {
+        "id": 226,
+        "text": "Where's the one place you should never take your dog? A flea market.",
+        "categories": []
+    },
+    {
+        "id": 227,
+        "text": "How does Darth Vader like his bagels? On the dark side.",
+        "categories": []
+    },
+    {
+        "id": 228,
+        "text": "What do you call spaghetti in disguise? An impasta.",
+        "categories": []
+    },
+    {
+        "id": 229,
+        "text": "Why did the tailor get fired? He wasn't a good fit.",
+        "categories": []
+    },
+    {
+        "id": 230,
+        "text": "Where do elephants store luggage? In a trunk.",
+        "categories": []
+    },
+    {
+        "id": 231,
+        "text": "Did you hear about the red and blue ships that collided? All the sailors were marooned.",
+        "categories": []
+    },
+    {
+        "id": 232,
+        "text": "My neighbor gave me a new roof for free. He said it was on the house.",
+        "categories": []
+    },
+    {
+        "id": 233,
+        "text": "Did you hear about the teenager who failed his driving test? He thought it was a crash course.",
+        "categories": []
+    },
+    {
+        "id": 234,
+        "text": "Where do surfers learn to surf? At boarding school.",
+        "categories": []
+    },
+    {
+        "id": 235,
+        "text": "A duck walks into a bar and buys everyone a round. He tells the bartender, Put it on my bill.",
+        "categories": []
+    },
+    {
+        "id": 236,
+        "text": "What has a spine but no bones? A book.",
+        "categories": []
+    },
+    {
+        "id": 237,
+        "text": "What do you call a wizard who's good with ceramics? Harry Pottery.",
+        "categories": []
+    },
+    {
+        "id": 238,
+        "text": "Why did Marie Curie stop dating that guy? There was no chemistry.",
+        "categories": []
+    },
+    {
+        "id": 239,
+        "text": "Did you hear about the nurse who didn't want to become a doctor? She didn't have the patients.",
+        "categories": []
+    },
+    {
+        "id": 240,
+        "text": "Why did the tourist feel disappointed upon seeing the Liberty Bell? It wasn't all it was cracked up to be.",
+        "categories": []
+    },
+    {
+        "id": 241,
+        "text": "How did Vikings communicate with one another? By Norse code.",
+        "categories": []
+    },
+    {
+        "id": 242,
+        "text": "How did Benjamin Franklin feel when he discovered electricity? He was shocked!",
+        "categories": []
+    },
+    {
+        "id": 243,
+        "text": "Which is the worst sport to play? Bad-minton.",
+        "categories": []
+    },
+    {
+        "id": 244,
+        "text": "Why don't the other farm animals like playing basketball with pigs? They're ball hogs.",
+        "categories": []
+    },
+    {
+        "id": 245,
+        "text": "How do ghosts stay in shape? They exorcise.",
+        "categories": []
+    },
+    {
+        "id": 246,
+        "text": "What do rabbits need after getting caught in the rain? A hare dryer.",
+        "categories": []
+    },
+    {
+        "id": 247,
+        "text": "Why did the coach put the frog in the outfield? He's really good at catching flies.",
+        "categories": []
+    },
+    {
+        "id": 248,
+        "text": "What board game is popular in Prague? Czechers.",
+        "categories": []
+    },
+    {
+        "id": 249,
+        "text": "What kind of shoes does a lazy person wear? Loafers.",
+        "categories": []
+    },
+    {
+        "id": 250,
+        "text": "Why didn't the invisible man go to the dance? He didn't have any body to take.",
+        "categories": []
+    },
+    {
+        "id": 251,
+        "text": "Dad, did you get a haircut? No, I got them all cut!",
+        "categories": []
+    },
+    {
+        "id": 252,
+        "text": "What did one candle say to the other? Do you want to go out tonight?",
+        "categories": []
+    },
+    {
+        "id": 253,
+        "text": "Why did the bed wear a disguise? It was undercover.",
+        "categories": []
+    },
+    {
+        "id": 254,
+        "text": "What do you call a boomerang that doesn't come back? A stick.",
+        "categories": []
+    },
+    {
+        "id": 255,
+        "text": "What do you call a monster with a high IQ? Frank-Einstein.",
+        "categories": []
+    },
+    {
+        "id": 256,
+        "text": "Why was the Incredible Hulk so good at gardening? He had a green thumb.",
+        "categories": []
+    },
+    {
+        "id": 257,
+        "text": "What kind of music does a boulder like? Rock ‘n' roll.",
+        "categories": []
+    },
+    {
+        "id": 258,
+        "text": "Why did the elephant quit his job? He was working for peanuts.",
+        "categories": []
+    },
+    {
+        "id": 259,
+        "text": "What did the shovel say to the sand? I really dig you!",
+        "categories": []
+    },
+    {
+        "id": 260,
+        "text": "What are the least expensive type of teeth? Buck teeth.",
+        "categories": []
+    },
+    {
+        "id": 261,
+        "text": "What would happen if you threw all the books in the ocean? It would cause a title wave.",
+        "categories": []
+    },
+    {
+        "id": 262,
+        "text": "Why did the queen go to the dentist? To get crowns on her teeth.",
+        "categories": []
+    },
+    {
+        "id": 263,
+        "text": "What's the best kind of music to listen to when fishing? Something catchy.",
+        "categories": []
+    },
+    {
+        "id": 264,
+        "text": "How did the pirate get his ship for so cheap? It was on sail.",
+        "categories": []
+    },
+    {
+        "id": 265,
+        "text": "Today my son asked me, Can I have a bookmark? I burst into tears — he's 12 years old and still doesn't know my name!",
+        "categories": []
+    },
+    {
+        "id": 266,
+        "text": "Why do dads take an extra pair of socks when they play golf? In case they get a hole in one.",
+        "categories": []
+    },
+    {
+        "id": 267,
+        "text": "What do you call a fish with no eyes? A fsh.",
+        "categories": []
+    },
+    {
+        "id": 268,
+        "text": "Why don't seagulls fly over the bay? Because then they'd be bagels (bay gulls).",
+        "categories": []
+    },
+    {
+        "id": 269,
+        "text": "What comes once in a minute, twice in a moment but never in a thousand years? The letter M.",
+        "categories": []
+    },
+    {
+        "id": 270,
+        "text": "What's the best kind of bird to work for at a construction company? A crane.",
+        "categories": []
+    },
+    {
+        "id": 271,
+        "text": "What did the T-Rex use to cut wood? A dino-saw.",
+        "categories": []
+    },
+    {
+        "id": 272,
+        "text": "I got fired from my job as a taxi driver. It turns out nobody thought I was fare.",
+        "categories": []
+    },
+    {
+        "id": 273,
+        "text": "What do you call a snake that loves building houses? A boa constructor.",
+        "categories": []
+    },
+    {
+        "id": 274,
+        "text": "Where do fish keep their money? In a river bank.",
+        "categories": []
+    },
+    {
+        "id": 275,
+        "text": "Why did the man put his money in the freezer? He wanted cold, hard cash.",
+        "categories": []
+    },
+    {
+        "id": 276,
+        "text": "When does it rain money? When there is a change in the weather.",
+        "categories": []
+    },
+    {
+        "id": 277,
+        "text": "Why don't scientists trust atoms? Because they make up everything.",
+        "categories": []
+    },
+    {
+        "id": 278,
+        "text": "What do a tick and the Eiffel Tower have in common? They're both Paris sites.",
+        "categories": []
+    },
+    {
+        "id": 279,
+        "text": "Why did the man get fired from the banana factory? He kept throwing away the bent ones.",
+        "categories": []
+    },
+    {
+        "id": 280,
+        "text": "Whoever stole my depression medication — I hope you're happy now.",
+        "categories": []
+    },
+    {
+        "id": 281,
+        "text": "Why can't a leopard hide? Because he's always spotted.",
+        "categories": []
+    },
+    {
+        "id": 282,
+        "text": "What do you call two monkeys who share an Amazon account? Prime mates.",
+        "categories": []
+    },
+    {
+        "id": 283,
+        "text": "What do you call a penguin in the White House? Lost.",
+        "categories": []
+    },
+    {
+        "id": 284,
+        "text": "What do you call a kangaroo's lazy joey? A pouch potato.",
+        "categories": []
+    },
+    {
+        "id": 285,
+        "text": "What did the llama say to his date? Want to go on a picnic? Alpaca lunch.",
+        "categories": []
+    },
+    {
+        "id": 286,
+        "text": "Did you hear that I'm reading a book about anti-gravity? It's impossible to put down.",
+        "categories": []
+    },
+    {
+        "id": 287,
+        "text": "Which is faster, hot or cold? Hot, because you can catch a cold.",
+        "categories": []
+    },
+    {
+        "id": 288,
+        "text": "Which bear is the most condescending? A pan-duh.",
+        "categories": []
+    },
+    {
+        "id": 289,
+        "text": "What kind of noise does a witch's vehicle make? Brrrroooom, brrroooom.",
+        "categories": []
+    },
+    {
+        "id": 290,
+        "text": "Singing in the shower is fun until you get soap in your mouth. Then it's a soap opera.",
+        "categories": []
+    },
+    {
+        "id": 291,
+        "text": "I only know 25 letters of the alphabet. I don't know y.",
+        "categories": []
+    },
+    {
+        "id": 292,
+        "text": "How does the moon cut his hair? Eclipse it.",
+        "categories": []
+    },
+    {
+        "id": 293,
+        "text": "What do you call a factory that makes OK products? A satisfactory.",
+        "categories": []
+    },
+    {
+        "id": 294,
+        "text": "What did the janitor say when he jumped out the closet? Supplies!",
+        "categories": []
+    },
+    {
+        "id": 295,
+        "text": "What did the buffalo say to his son when he dropped him off at school? Bison!",
+        "categories": []
+    },
+    {
+        "id": 296,
+        "text": "I can tolerate algebra, maybe even a little calculus, but geometry is where I draw the line.",
+        "categories": []
+    },
+    {
+        "id": 297,
+        "text": "Why do bees have sticky hair? Because they use a honeycomb.",
+        "categories": []
+    },
+    {
+        "id": 298,
+        "text": "What kind of music do chiropractors like? Hip pop.",
+        "categories": []
+    },
+    {
+        "id": 299,
+        "text": "What has five toes and isn't your foot? My foot.",
+        "categories": []
+    },
+    {
+        "id": 300,
+        "text": "What did the cannibal choose as his last meal? Five Guys.",
+        "categories": []
+    },
+    {
+        "id": 301,
+        "text": "Me: Go to bed, the cows are already asleep in the field. Son: So what? Me: It's pasture bedtime.",
+        "categories": []
+    },
+    {
+        "id": 302,
+        "text": "What do you call a Frenchman in sandals? Philippe Philoppe.",
+        "categories": []
+    },
+    {
+        "id": 303,
+        "text": "I bought the world's worst thesaurus yesterday. Not only is it terrible, it's terrible.",
+        "categories": []
+    },
+    {
+        "id": 304,
+        "text": "Why did the scarecrow get an award? Because he was outstanding in his field.",
+        "categories": []
+    },
+    {
+        "id": 305,
+        "text": "What do you get if you cross an angry sheep with a moody cow? An animal that's in a baaaaad mooood.",
+        "categories": []
+    },
+    {
+        "id": 306,
+        "text": "Can a kangaroo jump higher than the Empire State Building? Of course! Buildings can't jump.",
+        "categories": []
+    },
+    {
+        "id": 307,
+        "text": "What did the sink tell the toilet? You look flushed.",
+        "categories": []
+    },
+    {
+        "id": 308,
+        "text": "What happens when a snowman throws a tantrum? He has a meltdown.",
+        "categories": []
+    },
+    {
+        "id": 309,
+        "text": "My extra winter weight is finally gone. Now, I have spring rolls.",
+        "categories": []
+    },
+    {
+        "id": 310,
+        "text": "I just found out I'm colorblind. The news came out of the orange!",
+        "categories": []
+    },
+    {
+        "id": 311,
+        "text": "Did you hear that laughing too loudly is illegal in Hawaii? They only permit a-low-ha.",
+        "categories": []
+    },
+    {
+        "id": 312,
+        "text": "I hate my job — all I do is crush cans all day. It's soda pressing.",
+        "categories": []
+    },
+    {
+        "id": 313,
+        "text": "Mom keeps asking why I have so much candy. She doesn't know I always keep a few Twix up my sleeve.",
+        "categories": []
+    },
+    {
+        "id": 314,
+        "text": "I found a wooden shoe in my toilet — it was clogged.",
+        "categories": []
+    },
+    {
+        "id": 315,
+        "text": "If a pig loses its voice, does it become disgruntled?",
+        "categories": []
+    },
+    {
+        "id": 316,
+        "text": "I love dad jokes, but I don't have kids, which makes me a Faux Pa.",
+        "categories": []
+    },
+    {
+        "id": 317,
+        "text": "I only know 25 letters of the alphabet — I just don't know y.",
+        "categories": []
+    },
+    {
+        "id": 318,
+        "text": "My dream job is to clean mirrors, because I can really see myself doing that.",
+        "categories": []
+    },
+    {
+        "id": 319,
+        "text": "I lost 25",
+        "categories": [
+            "Last",
+            "My",
+            "Night...oof.",
+            "Of",
+            "Roof"
+        ]
+    },
+    {
+        "id": 320,
+        "text": "I don't trust stairs. They're always up to something.",
+        "categories": []
+    },
+    {
+        "id": 321,
+        "text": "RIP, boiling water. You will be mist.",
+        "categories": []
+    },
+    {
+        "id": 322,
+        "text": "Two guys walked into a bar. The third guy ducked.",
+        "categories": []
+    },
+    {
+        "id": 323,
+        "text": "Two peanuts went walking down the street. One was assaulted.",
+        "categories": []
+    },
+    {
+        "id": 324,
+        "text": "I'm so good at sleeping that I can do it with my eyes closed!",
+        "categories": []
+    },
+    {
+        "id": 325,
+        "text": "I had a dream that I weighed less than a thousandth of a gram. I was like, 0mg.",
+        "categories": []
+    },
+    {
+        "id": 326,
+        "text": "Mom said I should do lunges to stay in shape. That would be a big step forward.",
+        "categories": []
+    },
+    {
+        "id": 327,
+        "text": "Time flies like an arrow. Fruit flies like a banana.",
+        "categories": []
+    },
+    {
+        "id": 328,
+        "text": "Every time I take my dog to the park, the ducks try to bite him. That's what I get for buying a pure bread dog.",
+        "categories": []
+    },
+    {
+        "id": 329,
+        "text": "6:30 is my favorite time of day, hands down.",
+        "categories": []
+    },
+    {
+        "id": 330,
+        "text": "Whenever you get a bad sausage, it's just the wurst.",
+        "categories": []
+    },
+    {
+        "id": 331,
+        "text": "My dog is a genius. I asked him, What's two minus two? He said nothing.",
+        "categories": []
+    },
+    {
+        "id": 332,
+        "text": "I used to run a dating service for chickens, but I was struggling to make hens meet.",
+        "categories": []
+    },
+    {
+        "id": 333,
+        "text": "Mom texted me to say our Italian restaurant is out of pasta, and now we're penneless.",
+        "categories": []
+    },
+    {
+        "id": 334,
+        "text": "Justice is a dish best served cold. If it were served warm, it would be justwater.",
+        "categories": []
+    },
+    {
+        "id": 335,
+        "text": "I used to hate facial hair, but then it grew on me.",
+        "categories": []
+    },
+    {
+        "id": 336,
+        "text": "Most people can't tell the difference between entomology and etymology. I can't find the words for how much this bugs me.",
+        "categories": []
+    },
+    {
+        "id": 337,
+        "text": "A magician was walking down the street — then he turned into a store.",
+        "categories": []
+    },
+    {
+        "id": 338,
+        "text": "We're renovating the house, and the first floor is going great, but the second floor is another story.",
+        "categories": []
+    },
+    {
+        "id": 339,
+        "text": "I'm reading an anti-gravity book, and I just can't put it down!",
+        "categories": []
+    },
+    {
+        "id": 340,
+        "text": "At first, I thought my chiropractor wasn't any good, but now I stand corrected.",
+        "categories": []
+    },
+    {
+        "id": 341,
+        "text": "My toddler is refusing to nap. He's guilty of resisting a rest.",
+        "categories": []
+    },
+    {
+        "id": 342,
+        "text": "I used to be able to play piano by ear, but now I have to use my hands.",
+        "categories": []
+    },
+    {
+        "id": 343,
+        "text": "I failed my calculus exam because I was sitting in the middle of identical twins — I couldn't differentiate between them.",
+        "categories": []
+    },
+    {
+        "id": 344,
+        "text": "My boss asked me why I only get sick on work days. I said it must be my weekend immune system.",
+        "categories": []
+    },
+    {
+        "id": 345,
+        "text": "Every night, I have hard time remembering something, but then it dawns on me.",
+        "categories": []
+    },
+    {
+        "id": 346,
+        "text": "The wedding was so beautiful, even the cake was in tiers.",
+        "categories": []
+    },
+    {
+        "id": 347,
+        "text": "I can tolerate algebra, maybe even a little calculus but geometry is where I draw the line.",
+        "categories": []
+    },
+    {
+        "id": 348,
+        "text": "I was wondering why the baseball kept getting bigger and bigger. Then it hit me.",
+        "categories": []
+    },
+    {
+        "id": 349,
+        "text": "Have you heard about the new corduroy pillows — they're making headlines!",
+        "categories": []
+    },
+    {
+        "id": 350,
+        "text": "My therapist told me I have problems expressing my emotions. Can't say I'm surprised.",
+        "categories": []
+    },
+    {
+        "id": 351,
+        "text": "I was once a personal trainer, until I gave a too-weak notice.",
+        "categories": []
+    },
+    {
+        "id": 352,
+        "text": "I just paid $100 for a belt that doesn't fit — what a huge waist!",
+        "categories": []
+    },
+    {
+        "id": 353,
+        "text": "I finally watched that documentary on clocks. It was about time.",
+        "categories": []
+    },
+    {
+        "id": 354,
+        "text": "Bigfoot is sometimes confused for Sasquatch — Yeti never complains.",
+        "categories": []
+    },
+    {
+        "id": 355,
+        "text": "Your mom and I let astrology get between us. It just Taurus apart.",
+        "categories": []
+    },
+    {
+        "id": 356,
+        "text": "A guy walked into a bar, and lost the limbo contest.",
+        "categories": []
+    },
+    {
+        "id": 357,
+        "text": "I wanted to eat a watch for lunch, but it was too time-consuming.",
+        "categories": []
+    },
+    {
+        "id": 358,
+        "text": "I ordered a chicken and an egg online. I'll let you know what comes first.",
+        "categories": []
+    },
+    {
+        "id": 359,
+        "text": "It's raining cats and dogs, so be careful not to step in a poodle.",
+        "categories": []
+    },
+    {
+        "id": 360,
+        "text": "I decided to sell the vacuum cleaner — it was just gathering dust!",
+        "categories": []
+    },
+    {
+        "id": 361,
+        "text": "My boss told me to have a good day, so I went home!",
+        "categories": []
+    },
+    {
+        "id": 362,
+        "text": "Mom says I have no sense of direction, so I packed my bags and right.",
+        "categories": []
+    },
+    {
+        "id": 363,
+        "text": "If money doesn't grow on trees, then why do banks have branches?",
+        "categories": []
+    },
+    {
+        "id": 364,
+        "text": "Mom is mad at me because she asked me to sync her phone, so I threw it in the ocean.",
+        "categories": []
+    },
+    {
+        "id": 365,
+        "text": "I'd avoid the sushi if I were you — it's a little fishy!",
+        "categories": []
+    },
+    {
+        "id": 366,
+        "text": "I can tell when you're lying just by looking at you. I can also tell when you're standing.",
+        "categories": []
+    },
+    {
+        "id": 367,
+        "text": "I was going to go on an expensive vacation with a classical pianist, but he was too baroque.",
+        "categories": []
+    },
+    {
+        "id": 368,
+        "text": "Mom asked me to put ketchup on the grocery list, and now I can't read what else is on it.",
+        "categories": []
+    },
+    {
+        "id": 369,
+        "text": "Can anyone tell me what oblivious means, because I have no idea.",
+        "categories": []
+    },
+    {
+        "id": 370,
+        "text": "My friend couldn't pay his water bill, so I sent him a get well soon card",
+        "categories": []
+    },
+    {
+        "id": 371,
+        "text": "Does anybody know where a dad can find a person to talk to and hang out with? Asking for a friend.",
+        "categories": []
+    },
+    {
+        "id": 372,
+        "text": "Lance isn't that common a name these days, but in medieval times, they were called lance-a-lot.",
+        "categories": []
+    },
+    {
+        "id": 373,
+        "text": "After dinner Mom asked if I could clear the table. I needed a running start, but I made it.",
+        "categories": []
+    },
+    {
+        "id": 374,
+        "text": "I want to name my puppies Rolex and Timex so I can have watch dogs.",
+        "categories": []
+    },
+    {
+        "id": 375,
+        "text": "I love telling Dad jokes. Sometimes, he even laughs.",
+        "categories": []
+    },
+    {
+        "id": 376,
+        "text": "What does a baby computer call its father? Data!",
+        "categories": []
+    },
+    {
+        "id": 377,
+        "text": "What's green and has wheels? Grass! I lied about the wheels.",
+        "categories": []
+    },
+    {
+        "id": 378,
+        "text": "Where do pirates get their hooks? Second hand stores!",
+        "categories": []
+    },
+    {
+        "id": 379,
+        "text": "Why are pupils are the last part of your body to stop working when you die? They dilate!",
+        "categories": []
+    },
+    {
+        "id": 380,
+        "text": "What do you call a line of dads waiting to get haircuts? The barberqueue!",
+        "categories": []
+    },
+    {
+        "id": 381,
+        "text": "What do you call a beehive with no exit? Unbelievable!",
+        "categories": []
+    },
+    {
+        "id": 382,
+        "text": "What did the doctor say to the panicked man who was afraid he was shrinking? Settle down — you'll have to learn to be a little patient!",
+        "categories": []
+    },
+    {
+        "id": 383,
+        "text": "Why was 2019 afraid of 2020? Because they had a fight and 2021!",
+        "categories": []
+    },
+    {
+        "id": 384,
+        "text": "Why should you never brush your teeth with your left hand Because a toothbrush works better!",
+        "categories": []
+    },
+    {
+        "id": 385,
+        "text": "What do you call a rude cow? Beef jerky!",
+        "categories": []
+    },
+    {
+        "id": 386,
+        "text": "What's the best thing about living in Switzerland? I don't know, but the flag is a big plus!",
+        "categories": []
+    },
+    {
+        "id": 387,
+        "text": "Why are balloons so expensive? Inflation!",
+        "categories": []
+    },
+    {
+        "id": 388,
+        "text": "What is the most popular time for a dentist appointment? Tooth hurty!",
+        "categories": []
+    },
+    {
+        "id": 389,
+        "text": "Do you want to hear two short jokes and a long joke? Joke! Joke! Jooooooooooooooooke.",
+        "categories": []
+    },
+    {
+        "id": 390,
+        "text": "What do you call cheese that isn't yours? Nacho cheese!",
+        "categories": []
+    },
+    {
+        "id": 391,
+        "text": "Why can't you send a duck to space? Because the bill would be astronomical!",
+        "categories": []
+    },
+    {
+        "id": 392,
+        "text": "What side of a tree grows the most branches? The outside!",
+        "categories": []
+    },
+    {
+        "id": 393,
+        "text": "What happened when the world's tongue-twister champion got arrested? They gave him a tough sentence.",
+        "categories": []
+    },
+    {
+        "id": 394,
+        "text": "Why did an old man fall in a well? Because he couldn't see that well!",
+        "categories": []
+    },
+    {
+        "id": 395,
+        "text": "Did you hear about that person who was afraid of jumping a hurdle? They got over it!",
+        "categories": []
+    },
+    {
+        "id": 396,
+        "text": "What do you call a fish with no eye? A fsh.",
+        "categories": []
+    },
+    {
+        "id": 397,
+        "text": "What breed of dog can jump higher than a skyscraper? Any breed of dog! Skyscrapers can't jump.",
+        "categories": []
+    },
+    {
+        "id": 398,
+        "text": "Why are elevator jokes so good? They work on many levels!",
+        "categories": []
+    },
+    {
+        "id": 399,
+        "text": "Why are peppers the best at archery? Because they habanero!",
+        "categories": []
+    },
+    {
+        "id": 400,
+        "text": "What state is known for its tiny beverages? Minnesota!",
+        "categories": []
+    },
+    {
+        "id": 401,
+        "text": "Why did the computer get mad at the printer? Because it didn't like its toner voice.",
+        "categories": []
+    },
+    {
+        "id": 402,
+        "text": "What did the three-legged dog say when he walked into a saloon? I'm looking for the man who shot my paw.",
+        "categories": []
+    },
+    {
+        "id": 403,
+        "text": "What's the best way to watch a fly-fishing tournament? Live stream it!",
+        "categories": []
+    },
+    {
+        "id": 404,
+        "text": "Why did the broom decide to go to bed? It was very sweepy!",
+        "categories": []
+    },
+    {
+        "id": 405,
+        "text": "Why are nurses always running out of red crayons? Because they often have to draw blood!",
+        "categories": []
+    },
+    {
+        "id": 406,
+        "text": "Did you hear about the square that got into a car accident? Yeah, now he's a rect-angle!",
+        "categories": []
+    },
+    {
+        "id": 407,
+        "text": "What do you call an illegally parked frog? Toad!",
+        "categories": []
+    },
+    {
+        "id": 408,
+        "text": "How do you tell the difference between a bull and a cow? It is either one or the utter.",
+        "categories": []
+    },
+    {
+        "id": 409,
+        "text": "What's red and smells like blue paint? Red paint!",
+        "categories": []
+    },
+    {
+        "id": 410,
+        "text": "Why can't you ever run through a campsite? You can only ran — it's always past tents!",
+        "categories": []
+    },
+    {
+        "id": 411,
+        "text": "Why was the woman afraid for the calendar? She said its days were numbered!",
+        "categories": []
+    },
+    {
+        "id": 412,
+        "text": "Why is it hard to understand volunteers? Because they make no cents!",
+        "categories": []
+    },
+    {
+        "id": 413,
+        "text": "What did the police officer say to his belly-button? You're under a vest!",
+        "categories": []
+    },
+    {
+        "id": 414,
+        "text": "What's the easiest way to burn 1,000 calories? Leave the pizza in the oven!",
+        "categories": []
+    },
+    {
+        "id": 415,
+        "text": "What do you call a hippie's wife? Mississippi!",
+        "categories": []
+    },
+    {
+        "id": 416,
+        "text": "What's the difference between a badly dressed kid on a bicycle and a well dressed kid on a tricycle? Attire!",
+        "categories": []
+    },
+    {
+        "id": 417,
+        "text": "What did the drummer call his twin daughters? Anna One, Anna Two!",
+        "categories": []
+    },
+    {
+        "id": 418,
+        "text": "Did you hear about the king who was exactly 12 inches tall? He was a great ruler!",
+        "categories": []
+    },
+    {
+        "id": 419,
+        "text": "What's the difference between a hippo and a Zippo? One is very heavy, the other is a little lighter.",
+        "categories": []
+    },
+    {
+        "id": 420,
+        "text": "How do you cure a fear of a speed bump? You slowly get over it.",
+        "categories": []
+    },
+    {
+        "id": 421,
+        "text": "Why is the cow always smiling? It's in a good mooood I guess!",
+        "categories": []
+    },
+    {
+        "id": 422,
+        "text": "When did they find water on the moon? When it was waning!",
+        "categories": []
+    },
+    {
+        "id": 423,
+        "text": "What do you call a boomerang that doesn't come back? A stick!",
+        "categories": []
+    },
+    {
+        "id": 424,
+        "text": "Why is Peter Pan always flying? Because he Neverlands!",
+        "categories": []
+    },
+    {
+        "id": 425,
+        "text": "Why don't astronomers like Orion's Belt? It's a big waist of space!",
+        "categories": []
+    },
+    {
+        "id": 426,
+        "text": "What did the photon say to the hotel bellhop? No luggage, I'm traveling light!",
+        "categories": []
+    },
+    {
+        "id": 427,
+        "text": "Why did the coffee go to the police? To report a mugging!",
+        "categories": []
+    },
+    {
+        "id": 428,
+        "text": "What's the difference between a dad joke and a bad joke? The direction of the first letter.",
+        "categories": []
+    },
+    {
+        "id": 429,
+        "text": "I have a joke about putting in a light bulb, but I'm afraid I'll screw it up.",
+        "categories": []
+    },
+    {
+        "id": 430,
+        "text": "I have a joke about chemistry, but I don't think it'll get a reaction.",
+        "categories": []
+    },
+    {
+        "id": 431,
+        "text": "I have a joke about banking, but I lost interest.",
+        "categories": []
+    },
+    {
+        "id": 432,
+        "text": "I have a joke about cows, but I don't want to milk it.",
+        "categories": []
+    },
+    {
+        "id": 433,
+        "text": "I have a joke about kites, but it would just sail over your head.",
+        "categories": []
+    },
+    {
+        "id": 434,
+        "text": "I have a joke about scary math, but I'm 2² to say it.",
+        "categories": []
+    },
+    {
+        "id": 435,
+        "text": "I have a joke about construction, but I'm still working on it.",
+        "categories": []
+    },
+    {
+        "id": 436,
+        "text": "I have a joke about time travel, but you guys didn't get it.",
+        "categories": []
+    },
+    {
+        "id": 437,
+        "text": "I have a joke about being an electrician, but it's too shocking.",
+        "categories": []
+    },
+    {
+        "id": 438,
+        "text": "I have a joke about hunting for fossils, but you probably wouldn't dig it.",
+        "categories": []
+    },
+    {
+        "id": 439,
+        "text": "I have a joke about a broken pencil, but it's pointless.",
+        "categories": []
+    },
+    {
+        "id": 440,
+        "text": "I have a joke about the flu, but I hope you don't get it.",
+        "categories": []
+    },
+    {
+        "id": 441,
+        "text": "I have a joke about statistics, but it's not significant.",
+        "categories": []
+    },
+    {
+        "id": 442,
+        "text": "I have a joke about pizza, but it's too cheesy.",
+        "categories": []
+    },
+    {
+        "id": 443,
+        "text": "I have a joke about immortality, and it never gets old.",
+        "categories": []
+    },
+    {
+        "id": 444,
+        "text": "I have a joke about paper, but it's tearable.",
+        "categories": []
+    },
+    {
+        "id": 445,
+        "text": "I have a joke about trickle-down economics, but 99",
+        "categories": [
+            "Get",
+            "It.",
+            "Never",
+            "Of",
+            "Will",
+            "You"
+        ]
+    },
+    {
+        "id": 446,
+        "text": "I have a joke about drilling, but it's boring.",
+        "categories": []
+    },
+    {
+        "id": 447,
+        "text": "I have a joke about being a rejected organ donor, but I just don't have the guts to tell it.",
+        "categories": []
+    },
+    {
+        "id": 448,
+        "text": "I had a joke about canned juice, but I couldn't concentrate.",
+        "categories": []
+    },
+    {
+        "id": 449,
+        "text": "I have a few jokes about retired people, but none of them work.",
+        "categories": []
+    },
+    {
+        "id": 450,
+        "text": "I have a joke about a broken clock, but it's not the right time.",
+        "categories": []
+    },
+    {
+        "id": 451,
+        "text": "I have a joke about nepotism, but I'll only give it to my kids.",
+        "categories": []
+    },
+    {
+        "id": 452,
+        "text": "I have a joke about butter, but I'm not going to spread it.",
+        "categories": []
+    },
+    {
+        "id": 453,
+        "text": "I have a joke about a roof, but it would just go over your head.",
+        "categories": []
+    },
+    {
+        "id": 454,
+        "text": "I have a joke about inferiority complexes, but it's not very good.",
+        "categories": []
+    },
+    {
+        "id": 455,
+        "text": "I have a joke about procrastination, but I'll tell it to you later.",
+        "categories": []
+    },
+    {
+        "id": 456,
+        "text": "Why does Marvel advertise The Hulk the most? Because he's basically one big Banner!",
+        "categories": []
+    },
+    {
+        "id": 457,
+        "text": "What's E.T. short for? Because he's only got tiny legs!",
+        "categories": []
+    },
+    {
+        "id": 458,
+        "text": "What concert costs just 45 cents? 50 Cent featuring Nickelback!",
+        "categories": []
+    },
+    {
+        "id": 459,
+        "text": "What's Forrest Gump's email password? 1Forrest1",
+        "categories": []
+    },
+    {
+        "id": 460,
+        "text": "What does Jeff Bezos do before he goes to sleep? He puts his PJ-Amazon.",
+        "categories": []
+    },
+    {
+        "id": 461,
+        "text": "How do you follow Will Smith in the snow? You follow the fresh prints.",
+        "categories": []
+    },
+    {
+        "id": 462,
+        "text": "How does Darth Vader like his toast? On the dark side.",
+        "categories": []
+    },
+    {
+        "id": 463,
+        "text": "Why won't Apple start making cars? They wouldn't support windows.",
+        "categories": []
+    },
+    {
+        "id": 464,
+        "text": "What type of coordination was Whitney Houston most famous for? Hand eeeeyeeeeee!",
+        "categories": []
+    },
+    {
+        "id": 465,
+        "text": "What do you say when Dwayne Johnson buys something to cut with? Rock pay-for scissors.",
+        "categories": []
+    },
+    {
+        "id": 466,
+        "text": "To the person stole my laptop with my copy of Microsoft Office on it: I will find you. You have my Word!",
+        "categories": []
+    },
+    {
+        "id": 467,
+        "text": "To the person who stole my glasses: I will find you. I have contacts.",
+        "categories": []
+    },
+    {
+        "id": 468,
+        "text": "To the person who stole my place in line: I'm after you now.",
+        "categories": []
+    },
+    {
+        "id": 469,
+        "text": "To the person who stole my limbo stick: That was a new low.",
+        "categories": []
+    },
+    {
+        "id": 470,
+        "text": "To the person who stole my dictionary: I have no words.",
+        "categories": []
+    },
+    {
+        "id": 471,
+        "text": "To the person who stole my bed: I won't rest until I find you.",
+        "categories": []
+    },
+    {
+        "id": 472,
+        "text": "To the person who stole my depression medication: I hope you're happy now.",
+        "categories": []
+    },
+    {
+        "id": 473,
+        "text": "To the person who stole my case of energy drinks: I hope you can't sleep at night.",
+        "categories": []
+    },
+    {
+        "id": 474,
+        "text": "To the person who stole my power steering: I just can't handle it.",
+        "categories": []
+    },
+    {
+        "id": 475,
+        "text": "To the person who stole my diary and then died: My thoughts are with your family.",
+        "categories": []
+    },
+    {
+        "id": 476,
+        "text": "RIP boiling water, you will be mist.",
+        "categories": []
+    },
+    {
+        "id": 477,
+        "text": "I once wrote a song about a tortilla, but it's more of a wrap.",
+        "categories": []
+    },
+    {
+        "id": 478,
+        "text": "A witch's vehicle goes brrroom brrroom!",
+        "categories": []
+    },
+    {
+        "id": 479,
+        "text": "The waiter asked if I wanted a box for my leftovers, but I told him I'm not into fighting.",
+        "categories": []
+    },
+    {
+        "id": 480,
+        "text": "If you see a crime at an Apple store, are you an iWitness?",
+        "categories": []
+    },
+    {
+        "id": 481,
+        "text": "If the early bird catches the worm, I'll sleep in until there are pancakes.",
+        "categories": []
+    },
+    {
+        "id": 482,
+        "text": "The wedding was so beautiful, even the cake was in tiers.",
+        "categories": []
+    },
+    {
+        "id": 483,
+        "text": "I used to be able to play the piano by ear, but now I have to use my hands.",
+        "categories": []
+    },
+    {
+        "id": 484,
+        "text": "Did Noah include termites on the ark?",
+        "categories": []
+    },
+    {
+        "id": 485,
+        "text": "I used to hate facial hair, but it grew on me.",
+        "categories": []
+    },
+    {
+        "id": 486,
+        "text": "Keep the dream alive, and hit the snooze button.",
+        "categories": []
+    },
+    {
+        "id": 487,
+        "text": "I tell dad jokes but I have no kids. I'm a faux pa.",
+        "categories": []
+    },
+    {
+        "id": 488,
+        "text": "I'm afraid of speed bumps, but I am slowly getting over it.",
+        "categories": []
+    },
+    {
+        "id": 489,
+        "text": "Some people think prison is one word, but to robbers, it's the whole sentence.",
+        "categories": []
+    },
+    {
+        "id": 490,
+        "text": "I used to be addicted to soap, but I'm clean now.",
+        "categories": []
+    },
+    {
+        "id": 491,
+        "text": "Spring is here! I got so excited I wet my plants!",
+        "categories": []
+    },
+    {
+        "id": 492,
+        "text": "I poured root beer in a square glass. Now I just have beer.",
+        "categories": []
+    },
+    {
+        "id": 493,
+        "text": "I had a dream about being a muffler. I woke up exhausted.",
+        "categories": []
+    },
+    {
+        "id": 494,
+        "text": "Talk is cheap until you talk to a lawyer.",
+        "categories": []
+    },
+    {
+        "id": 495,
+        "text": "A pony with a cough is just a little horse.",
+        "categories": []
+    },
+    {
+        "id": 496,
+        "text": "It takes guts to be an organ donor.",
+        "categories": []
+    },
+    {
+        "id": 497,
+        "text": "To whoever stole my copy of Microsoft Office, I will find you. You have my Word!",
+        "categories": []
+    },
+    {
+        "id": 498,
+        "text": "How do celebrities stay cool? They have many fans.",
+        "categories": []
+    },
+    {
+        "id": 499,
+        "text": "What's Forrest Gump's Facebook password? 1forest1.",
+        "categories": []
+    },
+    {
+        "id": 500,
+        "text": "What did the fisherman say to the magician? Pick a cod, any cod.",
+        "categories": []
+    },
+    {
+        "id": 501,
+        "text": "What do you call a fake noodle? An impasta.",
+        "categories": []
+    },
+    {
+        "id": 502,
+        "text": "How do you organize a space party? You planet.",
+        "categories": []
+    },
+    {
+        "id": 503,
+        "text": "Did you know that milk is the fastest liquid on earth? It's pasteurized before you can even see it.",
+        "categories": []
+    },
+    {
+        "id": 504,
+        "text": "What does a baby computer call his father? Data.",
+        "categories": []
+    },
+    {
+        "id": 505,
+        "text": "Why can't a leopard hide? Because he's always spotted.",
+        "categories": []
+    },
+    {
+        "id": 506,
+        "text": "How many tickles does it take to make an octopus laugh? 10 tickles.",
+        "categories": []
+    },
+    {
+        "id": 507,
+        "text": "What do you call an illegally parked frog? Toad.",
+        "categories": []
+    },
+    {
+        "id": 508,
+        "text": "Why are spiders so smart? They can find everything on the web.",
+        "categories": []
+    },
+    {
+        "id": 509,
+        "text": "It's inappropriate to make a dad joke if you're not a dad. It's a faux pa.",
+        "categories": []
+    },
+    {
+        "id": 510,
+        "text": "Did you hear about the circus fire? It was in tents.",
+        "categories": []
+    },
+    {
+        "id": 511,
+        "text": "Can February March? No, but April May!",
+        "categories": []
+    },
+    {
+        "id": 512,
+        "text": "How do lawyers say goodbye? We'll be suing ya!",
+        "categories": []
+    },
+    {
+        "id": 513,
+        "text": "Wanna hear a joke about paper? Never mind—it's tearable.",
+        "categories": []
+    },
+    {
+        "id": 514,
+        "text": "What's the best way to watch a fly fishing tournament? Live stream.",
+        "categories": []
+    },
+    {
+        "id": 515,
+        "text": "I could tell a joke about pizza, but it's a little cheesy.",
+        "categories": []
+    },
+    {
+        "id": 516,
+        "text": "Every time I take my dog to the park, the ducks try to bite him. That's what I get for buying a pure bread dog.",
+        "categories": []
+    },
+    {
+        "id": 517,
+        "text": "What is a funny mountain called? Hill-arious.",
+        "categories": []
+    },
+    {
+        "id": 518,
+        "text": "I wouldn't buy anything with velcro. It's a total rip-off.",
+        "categories": []
+    },
+    {
+        "id": 519,
+        "text": "What time did the man go to the dentist? Tooth hurt-y.",
+        "categories": []
+    },
+    {
+        "id": 520,
+        "text": "What kind of egg did the evil chicken lay? A deviled egg.",
+        "categories": []
+    },
+    {
+        "id": 521,
+        "text": "Which is faster, hot or cold? Hot, because you can catch a cold.",
+        "categories": []
+    },
+    {
+        "id": 522,
+        "text": "I made a pencil with two erasers. It was pointless.",
+        "categories": []
+    },
+    {
+        "id": 523,
+        "text": "How does a bee brush its hair? It uses a honeycomb.",
+        "categories": []
+    },
+    {
+        "id": 524,
+        "text": "How do you make a Kleenex dance? Put a little boogie in it!",
+        "categories": []
+    },
+    {
+        "id": 525,
+        "text": "What do you get from a pampered cow? Spoiled milk!",
+        "categories": []
+    },
+    {
+        "id": 526,
+        "text": "Where do baby cats learn to swim? The kitty pool.",
+        "categories": []
+    },
+    {
+        "id": 527,
+        "text": "How can you tell it's a dogwood tree? From the bark.",
+        "categories": []
+    },
+    {
+        "id": 528,
+        "text": "What sound does the engine of a witch's vehicle make? Broooom broooom!",
+        "categories": []
+    },
+    {
+        "id": 529,
+        "text": "What do you call a fish wearing a bow tie? Sofishticated.",
+        "categories": []
+    },
+    {
+        "id": 530,
+        "text": "What bone will a dog never eat? A trombone.",
+        "categories": []
+    },
+    {
+        "id": 531,
+        "text": "Sundays are always a little sad, but the day before is a sadder day.",
+        "categories": []
+    },
+    {
+        "id": 532,
+        "text": "Where do you learn to make a banana split? Sundae school.",
+        "categories": []
+    },
+    {
+        "id": 533,
+        "text": "How do you row a canoe filled with puppies? Bring out the doggy paddle.",
+        "categories": []
+    },
+    {
+        "id": 534,
+        "text": "Why is cold water so insecure? Because it's never called hot.",
+        "categories": []
+    },
+    {
+        "id": 535,
+        "text": "I don't trust stairs. They're always up to something.",
+        "categories": []
+    },
+    {
+        "id": 536,
+        "text": "Why do bees have sticky hair? Because they use a honeycomb.",
+        "categories": []
+    },
+    {
+        "id": 537,
+        "text": "What did Tennessee? The same thing as Arkansas.",
+        "categories": []
+    },
+    {
+        "id": 538,
+        "text": "Why is it bad to iron your four-leaf clover? Because you shouldn't press your luck.",
+        "categories": []
+    },
+    {
+        "id": 539,
+        "text": "What rock group has four men who don't sing? Mount Rushmore.",
+        "categories": []
+    },
+    {
+        "id": 540,
+        "text": "Where do pirates buy hooks? The second hand store.",
+        "categories": []
+    },
+    {
+        "id": 541,
+        "text": "Why didn't the skeleton go on the rollercoaster? It didn't have the guts.",
+        "categories": []
+    },
+    {
+        "id": 542,
+        "text": "Why did the birds attack the dog? He was pure bread.",
+        "categories": []
+    },
+    {
+        "id": 543,
+        "text": "What did the nose tell the finger? Stop picking on me.",
+        "categories": []
+    },
+    {
+        "id": 544,
+        "text": "What do you call a sick lemon? Lemon-aid.",
+        "categories": []
+    },
+    {
+        "id": 545,
+        "text": "What gets wetter the more it dries? A towel.",
+        "categories": []
+    },
+    {
+        "id": 546,
+        "text": "What do you call a toothless bear? A gummy bear.",
+        "categories": []
+    },
+    {
+        "id": 547,
+        "text": "Why can't your hand be 12 inches long? Because then it would be a foot.",
+        "categories": []
+    },
+    {
+        "id": 548,
+        "text": "What has four wheels and flies? A garbage truck.",
+        "categories": []
+    },
+    {
+        "id": 549,
+        "text": "Why are pigs so bad at sports? Because they always hog the ball.",
+        "categories": []
+    },
+    {
+        "id": 550,
+        "text": "Time flies like an arrow. Fruit flies like a banana.",
+        "categories": []
+    },
+    {
+        "id": 551,
+        "text": "How do moths swim? Using the butterfly stroke.",
+        "categories": []
+    },
+    {
+        "id": 552,
+        "text": "What's an astronaut's favorite part of a computer? The space bar.",
+        "categories": []
+    },
+    {
+        "id": 553,
+        "text": "I hit in the head with a soda can. Thankfully it was a soft drink.",
+        "categories": []
+    },
+    {
+        "id": 554,
+        "text": "What's the name of my cheese? Nacho cheese.",
+        "categories": []
+    },
+    {
+        "id": 555,
+        "text": "Knock, knock. Who's there? Cows go. Cows go who? No, cows go moo!",
+        "categories": []
+    },
+    {
+        "id": 556,
+        "text": "What's the loudest pet you can own? A trumpet.",
+        "categories": []
+    },
+    {
+        "id": 557,
+        "text": "What did the buffalo say to his son when he dropped him off at school? Bison.",
+        "categories": []
+    },
+    {
+        "id": 558,
+        "text": "What does a pampered cow give? Spoiled milk.",
+        "categories": []
+    },
+    {
+        "id": 559,
+        "text": "I made a whopping six figures last year. I also was fired from the toy factory for being too slow.",
+        "categories": []
+    },
+    {
+        "id": 560,
+        "text": "Knock, knock. Who's there? A little old lady. A little old lady who? Hey, you can yodel!",
+        "categories": []
+    },
+    {
+        "id": 561,
+        "text": "Why did the teddy bear skip dessert? She was stuffed.",
+        "categories": []
+    },
+    {
+        "id": 562,
+        "text": "What did the left eye say to the right? Something smells between us.",
+        "categories": []
+    },
+    {
+        "id": 563,
+        "text": "What do you call a singing laptop? A Dell.",
+        "categories": []
+    },
+    {
+        "id": 564,
+        "text": "What's it called when a snowman throws a tantrum? A meltdown.",
+        "categories": []
+    },
+    {
+        "id": 565,
+        "text": "What did the scarecrow win an award for? He was outstanding in his field.",
+        "categories": []
+    },
+    {
+        "id": 566,
+        "text": "I don't know much about the best things in Switzerland, but their flag is a big plus.",
+        "categories": []
+    },
+    {
+        "id": 567,
+        "text": "I used to hate facial hair, but then it grew on me.",
+        "categories": []
+    },
+    {
+        "id": 568,
+        "text": "I invented a pencil with an eraser on each end. There's no point to it.",
+        "categories": []
+    },
+    {
+        "id": 569,
+        "text": "What do you call it when Batman skips church? Christian Bale.",
+        "categories": []
+    },
+    {
+        "id": 570,
+        "text": "Did you hear about the man who fell into an upholstery machine? He's fully recovered.",
+        "categories": []
+    },
+    {
+        "id": 571,
+        "text": "Why are skeletons so calm? Because nothing gets under their skin.",
+        "categories": []
+    },
+    {
+        "id": 572,
+        "text": "What's the astronaut's favorite part of a computer? The spacebar.",
+        "categories": []
+    },
+    {
+        "id": 573,
+        "text": "What did one ocean say to the other ocean? Nothing, they just waved.",
+        "categories": []
+    },
+    {
+        "id": 574,
+        "text": "Did you hear about the power outlet who got into a fight with a power cord? He thought he could socket to him.",
+        "categories": []
+    },
+    {
+        "id": 575,
+        "text": "Why are elevator jokes so good? They work on so many levels.",
+        "categories": []
+    },
+    {
+        "id": 576,
+        "text": "Why did the nurse need a red pen? In case she needed to draw blood.",
+        "categories": []
+    },
+    {
+        "id": 577,
+        "text": "Do you know the story about the chicken that crossed the border? Me neither, I couldn't follow it.",
+        "categories": []
+    },
+    {
+        "id": 578,
+        "text": "How can a leopard change his spots? By moving.",
+        "categories": []
+    },
+    {
+        "id": 579,
+        "text": "Don't trust atoms. They make up everything!",
+        "categories": []
+    },
+    {
+        "id": 580,
+        "text": "What's an astronaut's favorite part of a computer? The space bar.",
+        "categories": []
+    },
+    {
+        "id": 581,
+        "text": "I'm afraid of the calendar. Its days are numbered.",
+        "categories": []
+    },
+    {
+        "id": 582,
+        "text": "Two guys walked into a bar. The third guy ducked.",
+        "categories": []
+    },
+    {
+        "id": 583,
+        "text": "My wife said I should do lunges to stay in shape. That would be a big step forward.",
+        "categories": []
+    },
+    {
+        "id": 584,
+        "text": "What did the zero say to the eight? That belt looks good on you.",
+        "categories": []
+    },
+    {
+        "id": 585,
+        "text": "I got carded at a liquor store, and my Blockbuster card accidentally fell out. The cashier said never mind.",
+        "categories": []
+    },
+    {
+        "id": 586,
+        "text": "How do trees get online? They just log on.",
+        "categories": []
+    },
+    {
+        "id": 587,
+        "text": "How does the moon cut his hair? Eclipse it.",
+        "categories": []
+    },
+    {
+        "id": 588,
+        "text": "Air used to be free at the gas station. Now it's $1.50. You know why? Inflation.",
+        "categories": []
+    },
+    {
+        "id": 589,
+        "text": "When I was a kid, my mother told me I could be anyone I wanted to be. Turns out, identity theft is a crime.",
+        "categories": []
+    },
+    {
+        "id": 590,
+        "text": "I'll call you later. Don't call me later, call me Dad!",
+        "categories": []
+    },
+    {
+        "id": 591,
+        "text": "When does a joke become a dad joke? When it becomes apparent.",
+        "categories": []
+    },
+    {
+        "id": 592,
+        "text": "Which bear is the most condescending? A pan-duh.",
+        "categories": []
+    },
+    {
+        "id": 593,
+        "text": "What kind of drink can be bitter and sweet? Reali-tea.",
+        "categories": []
+    },
+    {
+        "id": 594,
+        "text": "Why do dads take an extra pair of socks when they golfing? In case they get a hole in one!",
+        "categories": []
+    },
+    {
+        "id": 595,
+        "text": "Singing in the shower is fun until you get soap in your mouth. Then it's a soap opera.",
+        "categories": []
+    },
+    {
+        "id": 596,
+        "text": "Where do fruits go on vacation? Pear-is.",
+        "categories": []
+    },
+    {
+        "id": 597,
+        "text": "Why do melons have weddings? Because they cantaloupe.",
+        "categories": []
+    },
+    {
+        "id": 598,
+        "text": "What kind of cars do eggs drive? Yolkswagens.",
+        "categories": []
+    },
+    {
+        "id": 599,
+        "text": "Why did the picture get arrested? It got framed.",
+        "categories": []
+    },
+    {
+        "id": 600,
+        "text": "Why do M&Ms go to school? Because they want to be a Smartie.",
+        "categories": []
+    },
+    {
+        "id": 601,
+        "text": "Knock knock. Who's there? Tank. Tank who? You're welcome.",
+        "categories": []
+    },
+    {
+        "id": 602,
+        "text": "How do you protect a bagel? Lox it up!",
+        "categories": []
+    },
+    {
+        "id": 603,
+        "text": "I like telling Dad jokes. Sometimes he laughs!",
+        "categories": []
+    },
+    {
+        "id": 604,
+        "text": "Why did the stadium get hot after the game? All of the fans left.",
+        "categories": []
+    },
+    {
+        "id": 605,
+        "text": "Why shouldn't you enter into a contract with Wolverine? Because of his retractable clause.",
+        "categories": []
+    },
+    {
+        "id": 606,
+        "text": "What kind of coffee does a vampire drink? De-coffin-ated.",
+        "categories": []
+    },
+    {
+        "id": 607,
+        "text": "How do you keep a skunk from smelling? Hold its nose!",
+        "categories": []
+    },
+    {
+        "id": 608,
+        "text": "What do you call a fish with two knees? A two-knee fish!",
+        "categories": []
+    },
+    {
+        "id": 609,
+        "text": "Why can't you tell a taco a secret? They tend to spill the beans!",
+        "categories": [
+            "Cinco",
+            "De",
+            "Mayo"
+        ]
+    },
+    {
+        "id": 610,
+        "text": "Dogs can't operate MRI machines. But catscan.",
+        "categories": []
+    },
+    {
+        "id": 611,
+        "text": "I wondered why the frisbee kept getting bigger and bigger. Then it hit me.",
+        "categories": []
+    },
+    {
+        "id": 612,
+        "text": "Why did the coach go to the bank? To get his quarter back.",
+        "categories": []
+    },
+    {
+        "id": 613,
+        "text": "Why do dads take an extra pair of socks when they golfing? In case they get a hole in one!",
+        "categories": []
+    },
+    {
+        "id": 614,
+        "text": "Singing in the shower is fun until you get soap in your mouth. Then it's a soap opera.",
+        "categories": []
+    },
+    {
+        "id": 615,
+        "text": "Where do fruits go on vacation? Pear-is.",
+        "categories": []
+    },
+    {
+        "id": 616,
+        "text": "I was wondering why the ball kept getting bigger and bigger… // And then it hit me.",
+        "categories": []
+    },
+    {
+        "id": 617,
+        "text": "Why do melons have weddings? Because they cantaloupe.",
+        "categories": []
+    },
+    {
+        "id": 618,
+        "text": "What kind of cars do eggs drive? Yolkswagens.",
+        "categories": []
+    },
+    {
+        "id": 619,
+        "text": "Every time I take my dog to the park, the ducks try to bite him. That's what I get for buying a pure bread dog.",
+        "categories": []
+    },
+    {
+        "id": 620,
+        "text": "Why does Snoop Dogg always carry an umbrella? Fo' Drizzle.",
+        "categories": []
+    },
+    {
+        "id": 621,
+        "text": "Why did the gym close down? It just didn't work out.",
+        "categories": []
+    },
+    {
+        "id": 622,
+        "text": "Two artists had an art contest. It ended in a draw.",
+        "categories": []
+    },
+    {
+        "id": 623,
+        "text": "Where are average things manufactured? The Satisfactory.",
+        "categories": []
+    },
+    {
+        "id": 624,
+        "text": "Want to hear a joke about construction? I'm still working on it.",
+        "categories": []
+    },
+    {
+        "id": 625,
+        "text": "What did one hat say to the other? Wait here, I'm going on ahead!",
+        "categories": []
+    },
+    {
+        "id": 626,
+        "text": "What cars do eggs drive? A Yolkswagen.",
+        "categories": []
+    },
+    {
+        "id": 627,
+        "text": "What does a baby computer call his father? Data.",
+        "categories": []
+    },
+    {
+        "id": 628,
+        "text": "After an unsuccessful harvest, why did the farmer decide to try a career in music? Because he had a ton of sick beets.",
+        "categories": []
+    },
+    {
+        "id": 629,
+        "text": "I only seem to get sick on weekdays. I must have a weekend immune system.",
+        "categories": []
+    },
+    {
+        "id": 630,
+        "text": "My friend was showing me his tool shed and pointed to a ladder. That's my stepladder. he said. I never knew my real ladder.",
+        "categories": []
+    },
+    {
+        "id": 631,
+        "text": "What do you call a Frenchman wearing sandals? Philippe Flop.",
+        "categories": []
+    },
+    {
+        "id": 632,
+        "text": "Why is it so cheap to throw a party at a haunted house? Because the ghosts bring all the boos.",
+        "categories": []
+    },
+    {
+        "id": 633,
+        "text": "I don't get why Marvel doesn't use the Hulk to advertise more. He's basically one big Banner.",
+        "categories": []
+    },
+    {
+        "id": 634,
+        "text": "What brand of underwear do scientists wear? Kelvin Klein.",
+        "categories": []
+    },
+    {
+        "id": 635,
+        "text": "Which days are the strongest? Saturday and Sunday. The rest are weekdays.",
+        "categories": []
+    },
+    {
+        "id": 636,
+        "text": "I just found out I'm colorblind. The news came out of the purple!",
+        "categories": []
+    },
+    {
+        "id": 637,
+        "text": "Did you know your pupils are the last part to stop working when you die? They dilate.",
+        "categories": []
+    },
+    {
+        "id": 638,
+        "text": "My wife asked me the other day where I got so much candy. I said, I always have a few Twix up my sleeve.",
+        "categories": []
+    },
+    {
+        "id": 639,
+        "text": "How do cows stay up to date? They read the Moo-spaper.",
+        "categories": []
+    },
+    {
+        "id": 640,
+        "text": "What's the difference between a well-dressed man on a unicycle and a poorly-dressed man on a bicycle? Attire.",
+        "categories": []
+    },
+    {
+        "id": 641,
+        "text": "I hate my job—all I do is crush cans all day. It's soda pressing.",
+        "categories": []
+    },
+    {
+        "id": 642,
+        "text": "Where do pirates get their hooks? Second hand stores.",
+        "categories": []
+    },
+    {
+        "id": 643,
+        "text": "Of all the inventions of the last 100 years, the dry erase board has to be the most remarkable.",
+        "categories": []
+    },
+    {
+        "id": 644,
+        "text": "In America, using the metric system can get you in legal trouble.",
+        "categories": []
+    },
+    {
+        "id": 645,
+        "text": "What do you call a line of men waiting to get haircuts? A barberqueue.",
+        "categories": []
+    },
+    {
+        "id": 646,
+        "text": "In fact, if you sneer at any other method of measuring liquids, you may be held in contempt of quart.",
+        "categories": []
+    },
+    {
+        "id": 647,
+        "text": "Who were the greenest Presidents in US history? The bushes.",
+        "categories": []
+    },
+    {
+        "id": 648,
+        "text": "My hotel tried to charge me ten dollars extra for air conditioning. That wasn't cool.",
+        "categories": []
+    },
+    {
+        "id": 649,
+        "text": "What do you call a beehive without an exit? Unbelievable.",
+        "categories": []
+    },
+    {
+        "id": 650,
+        "text": "If I ever find the doctor who screwed up my limb replacement surgery…I'll kill him with my bear hands.",
+        "categories": []
+    },
+    {
+        "id": 651,
+        "text": "Did you know that the first french fries weren't cooked in France? They were cooked in Greece.",
+        "categories": []
+    },
+    {
+        "id": 652,
+        "text": "This morning, Siri said, Don't call me Shirley. I accidentally left my phone in Airplane mode.",
+        "categories": []
+    },
+    {
+        "id": 653,
+        "text": "It's easy to convince ladies not to eat Tide Pods, but harder to deter gents.",
+        "categories": []
+    },
+    {
+        "id": 654,
+        "text": "I asked my date to meet me at the gym but she never showed up. I guess the two of us aren't going to work out.",
+        "categories": []
+    },
+    {
+        "id": 655,
+        "text": "How do you find Will Smith in a snowstorm? You look for fresh prints.",
+        "categories": []
+    },
+    {
+        "id": 656,
+        "text": "The difference between a numerator and a denominator is a short line. Only a fraction of people will understand this",
+        "categories": []
+    },
+    {
+        "id": 657,
+        "text": "I found a wooden shoe in my toilet today. It was clogged.",
+        "categories": []
+    },
+    {
+        "id": 658,
+        "text": "I just broke up with my mathematician girlfriend. She was obsessed with an X.",
+        "categories": []
+    },
+    {
+        "id": 659,
+        "text": "I can't take my dog to the pond anymore because the ducks keep attacking him. That's what I get for buying a pure bread dog.",
+        "categories": []
+    },
+    {
+        "id": 660,
+        "text": "To whoever stole my copy of Microsoft Office, I will find you. You have my Word.",
+        "categories": []
+    },
+    {
+        "id": 661,
+        "text": "What's Forrest Gump's password? 1forrest1.",
+        "categories": []
+    },
+    {
+        "id": 662,
+        "text": "I used to run a dating service for chickens. But I was struggling to make hens meet.",
+        "categories": []
+    },
+    {
+        "id": 663,
+        "text": "If prisoners could take their own mug shots…They'd be called cellfies.",
+        "categories": []
+    },
+    {
+        "id": 664,
+        "text": "Have you heard about those new corduroy pillows? They're making headlines.",
+        "categories": []
+    },
+    {
+        "id": 665,
+        "text": "If a pig loses its voice…does it become disgruntled?",
+        "categories": []
+    },
+    {
+        "id": 666,
+        "text": "Wanna hear a joke about paper? Never mind. It's tearable.",
+        "categories": []
+    },
+    {
+        "id": 667,
+        "text": "A panic-stricken man explained to his doctor, You have to help me, I think I'm shrinking. Now settle down, the doctor calmly told him. You'll just have to learn to be a little patient.",
+        "categories": []
+    },
+    {
+        "id": 668,
+        "text": "What do you call a bundle of hay in a church? Christian Bale.",
+        "categories": []
+    },
+    {
+        "id": 669,
+        "text": "A ship carrying red paint and a ship carrying blue paint collide in the middle of the ocean. Both crews were marooned.",
+        "categories": []
+    },
+    {
+        "id": 670,
+        "text": "What is a guitar player's favorite Italian food? Strum-boli.",
+        "categories": []
+    },
+    {
+        "id": 671,
+        "text": "How does cereal pay its bills? With Chex.",
+        "categories": []
+    },
+    {
+        "id": 672,
+        "text": "Have you heard about the restaurant on the moon? Great food, no atmosphere.",
+        "categories": []
+    },
+    {
+        "id": 673,
+        "text": "I don't trust stairs. They're always up to something.",
+        "categories": []
+    },
+    {
+        "id": 674,
+        "text": "People in Athens rarely get up before sunrise. Dawn is tough on Greece.",
+        "categories": []
+    },
+    {
+        "id": 675,
+        "text": "Why'd the alternate universe Spider-Man do so well on his driving test? He's an excellent parallel Parker.",
+        "categories": []
+    },
+    {
+        "id": 676,
+        "text": "Never date a tennis player. Love means nothing to them.",
+        "categories": []
+    },
+    {
+        "id": 677,
+        "text": "What's a lawyer's favorite drink? Subpoena colada.",
+        "categories": []
+    },
+    {
+        "id": 678,
+        "text": "What did Yoda say when he saw himself in 4K? HDMI.",
+        "categories": []
+    },
+    {
+        "id": 679,
+        "text": "What do you call a wizard who's really bad at football? Fumbledore.",
+        "categories": []
+    },
+    {
+        "id": 680,
+        "text": "How do nonbinary people hurt each other? They slash them. (They/them)",
+        "categories": []
+    },
+    {
+        "id": 681,
+        "text": "I used to hate facial hair, but then it grew on me.",
+        "categories": []
+    },
+    {
+        "id": 682,
+        "text": "What's blue and not very heavy? Light blue.",
+        "categories": []
+    },
+    {
+        "id": 683,
+        "text": "I don't get why bakers aren't wealthier. They make so much dough.",
+        "categories": []
+    },
+    {
+        "id": 684,
+        "text": "I asked my wife if I was the only one she slept with. She said yes—the others were 7's and 8's.",
+        "categories": []
+    },
+    {
+        "id": 685,
+        "text": "How do you make a tissue dance? You put a little boogie in it.",
+        "categories": []
+    },
+    {
+        "id": 686,
+        "text": "How do flat-earthers travel? On a plane.",
+        "categories": []
+    },
+    {
+        "id": 687,
+        "text": "I ordered a chicken and an egg from Amazon. I'll let you know.",
+        "categories": []
+    },
+    {
+        "id": 688,
+        "text": "Imagine if you walked into a bar and there was a long line of people waiting to take a swing at you. That's the punch line.",
+        "categories": []
+    },
+    {
+        "id": 689,
+        "text": "My wife left me because of my obsession with pasta. I'm feeling cannelloni right now.",
+        "categories": []
+    },
+    {
+        "id": 690,
+        "text": "What's an astronaut's favorite part of the computer? The Space Bar.",
+        "categories": []
+    },
+    {
+        "id": 691,
+        "text": "I was playing chess with my friend and he said, Let's make this interesting. So we stopped playing chess.",
+        "categories": []
+    },
+    {
+        "id": 692,
+        "text": "I was in a job interview the other day and they asked if I could perform under pressure. I said no, but I could perform Bohemian Rhapsody.",
+        "categories": []
+    },
+    {
+        "id": 693,
+        "text": "Why didn't the vampire attack Taylor Swift? She had bad blood.",
+        "categories": []
+    },
+    {
+        "id": 694,
+        "text": "Today I'm attaching a light to the ceiling, but I'm afraid I'll probably screw it up.",
+        "categories": []
+    },
+    {
+        "id": 695,
+        "text": "I hate it when people say age is only a number. Age is clearly a word.",
+        "categories": []
+    },
+    {
+        "id": 696,
+        "text": "I can't take my dog to the pond anymore because the ducks keep attacking him. That's what I get for buying a pure bread dog.",
+        "categories": []
+    },
+    {
+        "id": 697,
+        "text": "Someone complimented my parking today! They left a sweet note on my windshield that said parking fine.",
+        "categories": []
+    },
+    {
+        "id": 698,
+        "text": "I was excited to hear Apple might start selling its own cars until I learned they wouldn't support windows.",
+        "categories": []
+    },
+    {
+        "id": 699,
+        "text": "I just applied for a job down at the diner. I told them I really bring a lot to the table.",
+        "categories": []
+    },
+    {
+        "id": 700,
+        "text": "Cop: I'm arresting you for downloading the entire Wikipedia. Man: Wait! I can explain everything!",
+        "categories": []
+    },
+    {
+        "id": 701,
+        "text": "My friend couldn't afford to pay his bill, so I sent him a Get Well Soon card.",
+        "categories": []
+    },
+    {
+        "id": 702,
+        "text": "I'm Buzz Aldrin, second man to step on the moon. Neil before me.",
+        "categories": []
+    },
+    {
+        "id": 703,
+        "text": "Why was 2019 afraid of 2020? Because they had a fight and 2021.",
+        "categories": []
+    },
+    {
+        "id": 704,
+        "text": "Did you hear Bruce Springsteen changed the lyrics to one of his songs? What's he going to change next—his hair? His clothes? His face?",
+        "categories": []
+    },
+    {
+        "id": 705,
+        "text": "This year's Fibonacci convention is going to be really special. Apparently it's as big as the last two put together.",
+        "categories": []
+    },
+    {
+        "id": 706,
+        "text": "An apple a day keeps the doctor away. At least it does if you throw it hard enough.",
+        "categories": []
+    },
+    {
+        "id": 707,
+        "text": "I'm addicted to collecting vintage Beatles albums. I need Help.",
+        "categories": []
+    },
+    {
+        "id": 708,
+        "text": "In 2017 I didn't do a marathon. I didn't do one in 2018, 2019, or 2020, either. This is a running joke.",
+        "categories": []
+    },
+    {
+        "id": 709,
+        "text": "Not to brag but I made six figures last year. I was also named worst employee at the toy factory.",
+        "categories": []
+    },
+    {
+        "id": 710,
+        "text": "Ever since we started quarantining, I've only been telling inside jokes.",
+        "categories": []
+    },
+    {
+        "id": 711,
+        "text": "If you're feeling depressed, try drinking a gallon of water before you go to sleep. It'll give you a reason to get out of bed in the morning.",
+        "categories": []
+    },
+    {
+        "id": 712,
+        "text": "My landlord told me we need to talk about the heating bill. Sure, I said. My door is always open.",
+        "categories": []
+    },
+    {
+        "id": 713,
+        "text": "I built a model of Mount Everest and my son asked if it was to scale. No, I said. It's to look at.",
+        "categories": []
+    },
+    {
+        "id": 714,
+        "text": "What has five toes and isn't your foot? My foot.",
+        "categories": []
+    },
+    {
+        "id": 715,
+        "text": "My friend claims he glued himself to his autobiography. I don't believe him, but that's his story and he's sticking to it.",
+        "categories": []
+    },
+    {
+        "id": 716,
+        "text": "When I was a kid, my mother told me I could be anyone I wanted to be. Turns out, identity theft is a crime.",
+        "categories": []
+    },
+    {
+        "id": 717,
+        "text": "What's brown and sticky? A stick.",
+        "categories": []
+    },
+    {
+        "id": 718,
+        "text": "My doctor told me I was going deaf. The news was hard for me to hear.",
+        "categories": []
+    },
+    {
+        "id": 719,
+        "text": "A century ago, two brothers decided it was possible to fly. And as you can see, they were Wright.",
+        "categories": []
+    },
+    {
+        "id": 720,
+        "text": "I'm reading a horror story in braille. Something bad is going to happen, I can just feel it.",
+        "categories": []
+    },
+    {
+        "id": 721,
+        "text": "Anyone looking to buy a Delorean? Good shape, good mileage. Only driven from time to time",
+        "categories": []
+    },
+    {
+        "id": 722,
+        "text": "During my calculus test, I had to sit between identical twins. It was hard to differentiate between them.",
+        "categories": []
+    },
+    {
+        "id": 723,
+        "text": "Does anybody know where a guy can find a person to hang out with, talk to, and enjoy spending time with? I'm just asking for a friend.",
+        "categories": []
+    },
+    {
+        "id": 724,
+        "text": "Why did the Invisible Man turn down a job offer? He couldn't see himself doing it.",
+        "categories": []
+    },
+    {
+        "id": 725,
+        "text": "When I die, I want to be cremated. It's my last chance to have a smokin' hot body.",
+        "categories": []
+    },
+    {
+        "id": 726,
+        "text": "Just say NO to drugs! Well, if I'm talking to drugs, I probably already said yes.",
+        "categories": []
+    },
+    {
+        "id": 727,
+        "text": "I once saw a one-handed man in a second-hand store. I told him, I don't think they have what you're looking for, sir.",
+        "categories": []
+    },
+    {
+        "id": 728,
+        "text": "What do you call a sad cup of coffee? Depresso.",
+        "categories": []
+    },
+    {
+        "id": 729,
+        "text": "What did one monocle say to the other monocle? Let's get together and make a spectacle of ourselves.",
+        "categories": []
+    },
+    {
+        "id": 730,
+        "text": "How come the Hulk doesn't lose his pants when he transforms? The experiment altered his jeans.",
+        "categories": []
+    },
+    {
+        "id": 731,
+        "text": "I didn't want to believe that my dad was stealing from his job as a traffic cop, but when I got home, all the signs were there.",
+        "categories": []
+    },
+    {
+        "id": 732,
+        "text": "I just spent $300 on a limo and learned it doesn't come with a driver. I can't believe I have nothing to chauffer it.",
+        "categories": []
+    },
+    {
+        "id": 733,
+        "text": "What's green and has wheels? Grass. I lied about the wheels.",
+        "categories": []
+    },
+    {
+        "id": 734,
+        "text": "I have a joke about trickle down economics. But 99",
+        "categories": [
+            "Get",
+            "It.",
+            "Never",
+            "Of",
+            "Will",
+            "You"
+        ]
+    },
+    {
+        "id": 735,
+        "text": "Just got back from a job interview where I was asked if I could perform under pressure. I said I wasn't too sure about that but I could do a wicked Bohemian Rhapsody.",
+        "categories": []
+    },
+    {
+        "id": 736,
+        "text": "What's the best thing about living in Switzerland? I don't know, but the flag is a big plus.",
+        "categories": []
+    },
+    {
+        "id": 737,
+        "text": "At the job interview, they asked me, Where do you see yourself in five years? I told him, I think we'll still be using mirrors in five years.",
+        "categories": []
+    },
+    {
+        "id": 738,
+        "text": "A buddy asked how many fish I caught. I told him it's not polite to fish and tell.",
+        "categories": []
+    },
+    {
+        "id": 739,
+        "text": "How many clickbait articles does it take to change a lightbulb? The answer will shock you!",
+        "categories": []
+    },
+    {
+        "id": 740,
+        "text": "How do you make a water bed bouncier? Add spring water.",
+        "categories": []
+    },
+    {
+        "id": 741,
+        "text": "I always knock on the fridge door before opening it, just in case there's a salad dressing.",
+        "categories": []
+    },
+    {
+        "id": 742,
+        "text": "Where do dads store their dad jokes? In the dad-a-base.",
+        "categories": []
+    },
+    {
+        "id": 743,
+        "text": "What kind of fruit do ghosts like? Boo-berries.",
+        "categories": [
+            "Halloween"
+        ]
+    },
+    {
+        "id": 744,
+        "text": "I tried to start a professional hide and seek team, but it didn't work out. Turns out, good players are hard to find.",
+        "categories": []
+    },
+    {
+        "id": 745,
+        "text": "Women should not have children after 36—really, 36 children is enough.",
+        "categories": []
+    },
+    {
+        "id": 746,
+        "text": "What happens when frogs park illegally? They get toad.",
+        "categories": []
+    },
+    {
+        "id": 747,
+        "text": "Lance isn't that common a name these days, but in medieval times, they were called lance-a-lot.",
+        "categories": []
+    },
+    {
+        "id": 748,
+        "text": "I had an appointment to see my psychic next week, but she just called to cancel.",
+        "categories": []
+    },
+    {
+        "id": 749,
+        "text": "She said I won't be able to make it.",
+        "categories": []
+    },
+    {
+        "id": 750,
+        "text": "I used to be addicted to soap, but I'm clean now.",
+        "categories": []
+    },
+    {
+        "id": 751,
+        "text": "I wanted my kids to watch the orchestra, but I had to turn it off—too much sax and violins.",
+        "categories": []
+    },
+    {
+        "id": 752,
+        "text": "A cop started crying while he was writing me a ticket. I asked him why and he said, It's a moving violation.",
+        "categories": []
+    },
+    {
+        "id": 753,
+        "text": "Swords will never go obsolete. They're cutting edge technology.",
+        "categories": []
+    },
+    {
+        "id": 754,
+        "text": "I asked the IT guy, How do you make a Motherboard? He said, I tell her about my job.",
+        "categories": []
+    },
+    {
+        "id": 755,
+        "text": "What do you call it when James Bond takes a bath? Bubble 07.",
+        "categories": []
+    },
+    {
+        "id": 756,
+        "text": "30 percent of pet owners let their pets sleep in their bed. I tried it and my goldfish died.",
+        "categories": []
+    },
+    {
+        "id": 757,
+        "text": "What is the difference between a literalist and a kleptomaniac?",
+        "categories": []
+    },
+    {
+        "id": 758,
+        "text": "I just found out Albert Einstein existed. My whole life I thought he was a theoretical physicist.A comma. A literalist takes everything literally. A kleptomaniac takes everything, literally.",
+        "categories": []
+    },
+    {
+        "id": 759,
+        "text": "You used to be able to get air for free at gas stations, but now it's a $1. That's inflation for you.",
+        "categories": []
+    },
+    {
+        "id": 760,
+        "text": "My dad was born a conjoined twin, but separated at birth. So I have an uncle, once removed.",
+        "categories": []
+    },
+    {
+        "id": 761,
+        "text": "Why is it a bad idea to eat a clock? Because it's so time-consuming.",
+        "categories": []
+    },
+    {
+        "id": 762,
+        "text": "I went to a smoke shop only to discover it'd been replaced by an apparel store. Clothes, but no cigar.",
+        "categories": []
+    },
+    {
+        "id": 763,
+        "text": "Why should you never brush your teeth with your left hand? Because a toothbrush works better.",
+        "categories": []
+    },
+    {
+        "id": 764,
+        "text": "My grief counselor died the other day. He was so good at his job, I don't even care.",
+        "categories": []
+    },
+    {
+        "id": 765,
+        "text": "Give a man a plane ticket and he flies for the day. Push him out of the plane at 3,000 feet and he'll fly for the rest of his life.",
+        "categories": []
+    },
+    {
+        "id": 766,
+        "text": "As I get older, I remember all the people I lost along the way. Maybe a career as a tour guide was not the right choice.",
+        "categories": []
+    },
+    {
+        "id": 767,
+        "text": "I was reading a great book about an immortal dog the other day. It was impossible to put down.",
+        "categories": []
+    },
+    {
+        "id": 768,
+        "text": "What do you call someone who refuses to fart in public? A private tutor.",
+        "categories": []
+    },
+    {
+        "id": 769,
+        "text": "I just read that someone in London gets stabbed every 52 seconds. Poor bastard.",
+        "categories": []
+    },
+    {
+        "id": 770,
+        "text": "They say that breakfast is the most important meal of the day. Well, not if it's poisoned. Then the antidote becomes the most important.",
+        "categories": []
+    },
+    {
+        "id": 771,
+        "text": "The guy who stole my diary just died. My thoughts are with his family.",
+        "categories": []
+    },
+    {
+        "id": 772,
+        "text": "Do you know the last thing my grandfather said to me before he kicked the bucket? Grandson, watch how far I can kick this bucket.",
+        "categories": []
+    },
+    {
+        "id": 773,
+        "text": "If you donate a kidney, everybody loves you and you're a total hero. But try donating five kidneys and suddenly everyone is yelling and the police get called.",
+        "categories": []
+    },
+    {
+        "id": 774,
+        "text": "I have a fish that can breakdance. Only for ten seconds though, and only once.",
+        "categories": []
+    },
+    {
+        "id": 775,
+        "text": "My friend said that if he went off a cliff, it would be on his own accord. It's a good thing he drives a Civic.",
+        "categories": []
+    },
+    {
+        "id": 776,
+        "text": "In my free time, I like to help blind people. Verb, not adjective.",
+        "categories": []
+    },
+    {
+        "id": 777,
+        "text": "A doctor walks into a room with a dying patient and tells him, I'm sorry, but you only have ten left. The patient asks him, Ten what, Doc? Hours? Days? Weeks? The doctor calmly looks at him and says, Nine.",
+        "categories": []
+    },
+    {
+        "id": 778,
+        "text": "I like to spend my weekends playing chess with elderly men in the park. But it's becoming more difficult. You try finding exactly32 old guys.",
+        "categories": []
+    },
+    {
+        "id": 779,
+        "text": "What do you call bears with no ears? B.",
+        "categories": []
+    },
+    {
+        "id": 780,
+        "text": "What's the difference between a wizard who raises the undead and a sexy vampire? One is a necromancer and the other is a neck romancer.",
+        "categories": []
+    },
+    {
+        "id": 781,
+        "text": "A man walks into a magic forest and tries to cut down a talking tree. You can't cut me down, the tree complains. I'm a talking tree! The man responds, You may be a talking tree, but you will dialogue.",
+        "categories": []
+    },
+    {
+        "id": 782,
+        "text": "I heard Sony's coming out with a new console during the pandemic...It's called the Plaguestation 5.",
+        "categories": []
+    },
+    {
+        "id": 783,
+        "text": "When my uncle Frank died, he wanted his remains to be buried in his favorite beer mug. His last wish was to be Frank in Stein.",
+        "categories": []
+    },
+    {
+        "id": 784,
+        "text": "A man walks into a bar. The bartender asks, What do you want? The man says, Oh, just some fruit punch. The bartender sighs and shakes his head, If you want punch, you're gonna have to wait in line. The man looks around, but there is no punchline.",
+        "categories": []
+    },
+    {
+        "id": 785,
+        "text": "What's worse than biting into an apple and finding a worm? Biting into an apple and finding half a worm.",
+        "categories": []
+    },
+    {
+        "id": 786,
+        "text": "I just got my doctor's test results and I'm really upset. Turns out, I'm not gonna be a doctor.",
+        "categories": []
+    },
+    {
+        "id": 787,
+        "text": "My wife and I have decided not to have kids. The kids are taking it pretty badly.",
+        "categories": []
+    },
+    {
+        "id": 788,
+        "text": "When does a joke become a dad joke? When it becomes apparent.",
+        "categories": []
+    },
+    {
+        "id": 789,
+        "text": "My daughter just shrieked at me, Daaaaaad, you haven't listened to a word I've said, have you? What an odd way to begin a conversation.",
+        "categories": []
+    },
+    {
+        "id": 790,
+        "text": "I have a great joke about nepotism. But I'll only tell it to my kids.",
+        "categories": []
+    },
+    {
+        "id": 791,
+        "text": "Dad, can you explain to me what a solar eclipse is? No sun.",
+        "categories": []
+    },
+    {
+        "id": 792,
+        "text": "What happened when the ten-year-old cannibal spilled his soup? His mother gave him an earful.",
+        "categories": []
+    },
+    {
+        "id": 793,
+        "text": "I'd like to have kids one day. I don't think I could stand them any longer than that, though.",
+        "categories": []
+    },
+    {
+        "id": 794,
+        "text": "What did the buffalo say to his son when he dropped him off at school? Bison.",
+        "categories": []
+    },
+    {
+        "id": 795,
+        "text": "I wonder what my parents did to fight boredom before the internet. I asked my eighteen brothers and sisters but they didn't have any idea either.",
+        "categories": []
+    },
+    {
+        "id": 796,
+        "text": "My parents raised me as an only child. Which really annoyed my younger brother.",
+        "categories": []
+    },
+    {
+        "id": 797,
+        "text": "I tell dad jokes but I have no kids. I'm a faux pa!",
+        "categories": []
+    },
+    {
+        "id": 798,
+        "text": "A kid decided to burn his house down. His dad watched, tears in his eyes. He put his arm around the mom and said, That's arson.",
+        "categories": []
+    },
+    {
+        "id": 799,
+        "text": "Today I decided to go visit my childhood home. I asked the residents if I could come inside because I was feeling nostalgic, but they refused and slammed the door on my face. My parents are the worst.",
+        "categories": []
+    },
+    {
+        "id": 800,
+        "text": "What's your name, son? The principal asked his student. The kid replied, D-d-d-dav-dav-david, sir. Do you have a stutter? the principal asked. The student answered, No sir, my dad has a stutter but the guy who registered my name was a real jerk.",
+        "categories": []
+    },
+    {
+        "id": 801,
+        "text": "Concerned that his son was spending too much time on video games, a dad told him, When Abe Lincoln was your age, he was studying books by the light of the fireplace. Oh yeah? the son retorts. Well, when Abe Lincoln was your age, he was President of the United States.",
+        "categories": []
+    },
+    {
+        "id": 802,
+        "text": "A father tells his son that he was adopted. I want to meet my biological parents, the son demands. We are your biological parents, the father responds. Now pack up, the new ones will pick you up in twenty minutes.",
+        "categories": []
+    },
+    {
+        "id": 803,
+        "text": "A son tells his father, I have an imaginary girlfriend. The father sighs and says, You know, you could do better. Thanks Dad, the son says. That means a lot. The father shakes his head and goes, I was talking to your girlfriend.",
+        "categories": []
+    },
+    {
+        "id": 804,
+        "text": "Yesterday, I was washing the car with my son. He said, Dad, can't you just use a sponge?",
+        "categories": []
+    },
+    {
+        "id": 805,
+        "text": "My dad died because he couldn't remember his blood type. He kept insisting we be positive, but it's just so hard without him.",
+        "categories": []
+    },
+    {
+        "id": 806,
+        "text": "I tried to explain to my 4-year-old son that it's perfectly normal to accidentally poop your pants. But he's still making fun of me.",
+        "categories": []
+    },
+    {
+        "id": 807,
+        "text": "I wasn't close to my father when he died. Which is lucky because he stepped on a landmine.",
+        "categories": []
+    },
+    {
+        "id": 808,
+        "text": "April showers bring May flowers, but what do May flowers bring? Pilgrims.",
+        "categories": []
+    },
+    {
+        "id": 809,
+        "text": "What do you call a fake noodle? An Impasta.",
+        "categories": []
+    },
+    {
+        "id": 810,
+        "text": "How do you make a tissue dance? Put a little boogie in it.",
+        "categories": []
+    },
+    {
+        "id": 811,
+        "text": "What is a funny mountain called? Hill-arious.",
+        "categories": []
+    },
+    {
+        "id": 812,
+        "text": "What do you call a song about a tortilla? A wrap.",
+        "categories": []
+    },
+    {
+        "id": 813,
+        "text": "What's Forrest Gump's password? 1forrest1.",
+        "categories": []
+    },
+    {
+        "id": 814,
+        "text": "Where do pirates buy hooks? The second hand store.",
+        "categories": []
+    },
+    {
+        "id": 815,
+        "text": "The child refused to nap. She was found guilty of resisting a rest.",
+        "categories": []
+    },
+    {
+        "id": 816,
+        "text": "Why did the tomato blush? It saw the salad dressing!",
+        "categories": []
+    },
+    {
+        "id": 817,
+        "text": "Why is it bad to iron a four leaf clover? Because you should never press your luck.",
+        "categories": []
+    },
+    {
+        "id": 818,
+        "text": "What did one hat say to the other? Wait here, I'm going on ahead!",
+        "categories": []
+    },
+    {
+        "id": 819,
+        "text": "What keys unlock a banana? Mon-keys.",
+        "categories": []
+    },
+    {
+        "id": 820,
+        "text": "What is a fancy fish called? So-fish-ticated.",
+        "categories": []
+    },
+    {
+        "id": 821,
+        "text": "What's blue and doesn't weigh much? Light blue.",
+        "categories": []
+    },
+    {
+        "id": 822,
+        "text": "Where do you learn to make a banana split? Sundae school.",
+        "categories": []
+    },
+    {
+        "id": 823,
+        "text": "What happened to the frog that parked illegally? It got toad.",
+        "categories": []
+    },
+    {
+        "id": 824,
+        "text": "What type of bear is toothless? A gummy bear.",
+        "categories": []
+    },
+    {
+        "id": 825,
+        "text": "What cars do eggs drive? A Yolkswagen.",
+        "categories": []
+    },
+    {
+        "id": 826,
+        "text": "Why didn't the skeleton go on the rollercoaster? It didn't have the guts.",
+        "categories": []
+    },
+    {
+        "id": 827,
+        "text": "What did the cereal bring to the bank? Chex.",
+        "categories": []
+    },
+    {
+        "id": 828,
+        "text": "How does the moon style his hair? Eclipse it.",
+        "categories": []
+    },
+    {
+        "id": 829,
+        "text": "Why did the birds attack the dog? He was pure bread.",
+        "categories": []
+    },
+    {
+        "id": 830,
+        "text": "What did one wall say to the other? Let's meet at the corner.",
+        "categories": []
+    },
+    {
+        "id": 831,
+        "text": "Why couldn't the bicycle stand up alone? Because it was two tired.",
+        "categories": []
+    },
+    {
+        "id": 832,
+        "text": "How do you make seven even? Take away the s.",
+        "categories": []
+    },
+    {
+        "id": 833,
+        "text": "What's it called when a snowman throws a tantrum? A meltdown.",
+        "categories": []
+    },
+    {
+        "id": 834,
+        "text": "What did the scarecrow win an award for? He was outstanding in his field.",
+        "categories": []
+    },
+    {
+        "id": 835,
+        "text": "What cars do sheep drive? Lamborghinis.",
+        "categories": []
+    },
+    {
+        "id": 836,
+        "text": "How do cows learn about current events? They read the moo-spaper.",
+        "categories": []
+    },
+    {
+        "id": 837,
+        "text": "How do you make a water bed bouncier? Fill it with Poland Spring water.",
+        "categories": []
+    },
+    {
+        "id": 838,
+        "text": "I have a joke about construction, but I'm still working on it.",
+        "categories": []
+    },
+    {
+        "id": 839,
+        "text": "At least I know I can always count on my fingers.",
+        "categories": []
+    },
+    {
+        "id": 840,
+        "text": "I just gave my too weak notice at the gym.",
+        "categories": []
+    },
+    {
+        "id": 841,
+        "text": "I bought Velcro sneakers, but they were a total rip-off!",
+        "categories": []
+    },
+    {
+        "id": 842,
+        "text": "My dentist appointment is at tooth hurt-y.",
+        "categories": []
+    },
+    {
+        "id": 843,
+        "text": "Apparently it was the fridge shrinking my clothes…not the dryer.",
+        "categories": []
+    },
+    {
+        "id": 844,
+        "text": "Goodbye boiling water, you will be mist.",
+        "categories": []
+    },
+    {
+        "id": 845,
+        "text": "All the fruits go on vacation in Pear-is.",
+        "categories": []
+    },
+    {
+        "id": 846,
+        "text": "The dry-erase board is the most remarkable invention.",
+        "categories": []
+    },
+    {
+        "id": 847,
+        "text": "I brought an egg to a comedy show and he cracked up.",
+        "categories": []
+    },
+    {
+        "id": 848,
+        "text": "It takes a lot of guts to be an organ donor.",
+        "categories": []
+    },
+    {
+        "id": 849,
+        "text": "That ghost was such a bad liar…I could see right through him!",
+        "categories": [
+            "Halloween"
+        ]
+    },
+    {
+        "id": 850,
+        "text": "The football coach went to the bank to get his quarterback.",
+        "categories": []
+    },
+    {
+        "id": 851,
+        "text": "Spiders are so smart, they know everything on the web.",
+        "categories": [
+            "Halloween"
+        ]
+    },
+    {
+        "id": 852,
+        "text": "I used to have a fear of speed bumps, but I'm slowly getting over it.",
+        "categories": []
+    },
+    {
+        "id": 853,
+        "text": "I had to get a neck brace last year and I haven't looked back since.",
+        "categories": []
+    },
+    {
+        "id": 854,
+        "text": "That circus fire was in tents.",
+        "categories": []
+    },
+    {
+        "id": 855,
+        "text": "I don't want to be friends with Dracula anymore, he's such a pain in the neck!",
+        "categories": []
+    },
+    {
+        "id": 856,
+        "text": "It was easy to stop women from eating Tide Pods, but I couldn't deter gents.",
+        "categories": []
+    },
+    {
+        "id": 857,
+        "text": "A joke becomes a dad joke once it is apparent.",
+        "categories": []
+    },
+    {
+        "id": 858,
+        "text": "I don't know much about the best things in Switzerland, but their flag is a big plus.",
+        "categories": []
+    },
+    {
+        "id": 859,
+        "text": "That wedding was so emotional, even the cake was in tiers.",
+        "categories": []
+    },
+    {
+        "id": 860,
+        "text": "Everyone's sharing the rumor about butter, but I'm not about to spread it.",
+        "categories": []
+    },
+    {
+        "id": 861,
+        "text": "I told a joke about chemistry, but it didn't get a reaction.",
+        "categories": []
+    },
+    {
+        "id": 862,
+        "text": "I'm a big dreamer, so I always hit the snooze button.",
+        "categories": []
+    },
+    {
+        "id": 863,
+        "text": "I saw the Apple store get robbed…I guess that makes me an iWitness.",
+        "categories": []
+    },
+    {
+        "id": 864,
+        "text": "That car seems nice, but the muffler looks exhausted.",
+        "categories": []
+    },
+    {
+        "id": 865,
+        "text": "The ghost told me he'd bring the boos to the party tonight.",
+        "categories": [
+            "Halloween"
+        ]
+    },
+    {
+        "id": 866,
+        "text": "I used to hate facial hair, but then it grew on me.",
+        "categories": []
+    },
+    {
+        "id": 867,
+        "text": "That vampire should see a doctor…he's always coffin.",
+        "categories": [
+            "Halloween"
+        ]
+    },
+    {
+        "id": 868,
+        "text": "I'm following the seafood diet. I see food, then I eat it.",
+        "categories": []
+    },
+    {
+        "id": 869,
+        "text": "Why was 6 afraid of 7? Because 7 ate 9.",
+        "categories": []
+    },
+    {
+        "id": 870,
+        "text": "Dogs are not allowed to operate an MRI machine, but catscan!",
+        "categories": []
+    },
+    {
+        "id": 871,
+        "text": "Don't eat my cheese, that's nacho cheese!",
+        "categories": [
+            "Cinco",
+            "De",
+            "Mayo"
+        ]
+    },
+    {
+        "id": 872,
+        "text": "What computer is a singer? A Dell.",
+        "categories": []
+    },
+    {
+        "id": 873,
+        "text": "My boss wished me a good day, so I went back home.",
+        "categories": []
+    },
+    {
+        "id": 874,
+        "text": "Why do nurses always take the red crayons? They have to draw a lot of blood.",
+        "categories": []
+    },
+    {
+        "id": 875,
+        "text": "I had a clock for breakfast. It was super time-consuming.",
+        "categories": []
+    },
+    {
+        "id": 876,
+        "text": "What did one monocle say to the other monocle? Let's meet up and make a spectacle of ourselves.",
+        "categories": []
+    },
+    {
+        "id": 877,
+        "text": "It's painful to say this, but I have a bad sore throat.",
+        "categories": []
+    },
+    {
+        "id": 878,
+        "text": "What's the least spoken language? Sign language.",
+        "categories": []
+    },
+    {
+        "id": 879,
+        "text": "A cheese factory exploded downtown. Da brie is all over the streets!",
+        "categories": []
+    },
+    {
+        "id": 880,
+        "text": "I'm so good at napping that I can do it in my sleep!",
+        "categories": []
+    },
+    {
+        "id": 881,
+        "text": "I only know 25 letters of the alphabet. I don't know y.",
+        "categories": []
+    },
+    {
+        "id": 882,
+        "text": "What did one DNA molecule say to the other DNA molecule? How do these genes look on me?",
+        "categories": []
+    },
+    {
+        "id": 883,
+        "text": "Don't go in the grass without armor! It's full of blades!",
+        "categories": []
+    },
+    {
+        "id": 884,
+        "text": "Why did the invisible man decline the job offer? He couldn't see himself doing it.",
+        "categories": []
+    },
+    {
+        "id": 885,
+        "text": "How much money is it to park Santa's sleigh? Nothing. It's on the house.",
+        "categories": []
+    },
+    {
+        "id": 886,
+        "text": "I'm so bored at work because all I do is crush cans all day. It's soda pressing.",
+        "categories": []
+    },
+    {
+        "id": 887,
+        "text": "What does a buffalo say goodbye to his son? Bison.",
+        "categories": []
+    },
+    {
+        "id": 888,
+        "text": "3.14",
+        "categories": [
+            "Are",
+            "Considered",
+            "Of",
+            "Pi-rates.",
+            "Sailors"
+        ]
+    },
+    {
+        "id": 889,
+        "text": "What animal is the worst at hide-and-seek? A leopard because he's always spotted.",
+        "categories": []
+    },
+    {
+        "id": 890,
+        "text": "What do you call someone who doesn't have a nose or body? Nobody knows.",
+        "categories": []
+    },
+    {
+        "id": 891,
+        "text": "What does garlic do before it showers? Takes its cloves off.",
+        "categories": []
+    },
+    {
+        "id": 892,
+        "text": "Why did the dog float in the water? He was a good buoy.",
+        "categories": []
+    },
+    {
+        "id": 893,
+        "text": "I went to the restaurant on the moon. The food was delicious, but there was no atmosphere.",
+        "categories": []
+    },
+    {
+        "id": 894,
+        "text": "I invented a pencil with an eraser on each end. There's no point to it.",
+        "categories": []
+    },
+    {
+        "id": 895,
+        "text": "What has five toes, a heel, and isn't your foot? My foot.",
+        "categories": []
+    },
+    {
+        "id": 896,
+        "text": "Why didn't Han Solo like his burger? It was too Chewie.",
+        "categories": []
+    },
+    {
+        "id": 897,
+        "text": "What's the astronaut's favorite part of a computer? The spacebar.",
+        "categories": []
+    },
+    {
+        "id": 898,
+        "text": "If you spell the words absolutely nothing backward, you get gnihton yletulosba, which ironically means…absolutely nothing.",
+        "categories": []
+    },
+    {
+        "id": 899,
+        "text": "I had a joke about boxing, but I forgot the punchline.",
+        "categories": []
+    },
+    {
+        "id": 900,
+        "text": "The farmers lost all their crops and decided to try a career in music instead. They just had too many sick beets.",
+        "categories": []
+    },
+    {
+        "id": 901,
+        "text": "I once was addicted to soap, but I'm all clean now.",
+        "categories": []
+    },
+    {
+        "id": 902,
+        "text": "The saying goes, An apple a day keeps the doctor away, but they keep calling me for my annual checkup.",
+        "categories": []
+    },
+    {
+        "id": 903,
+        "text": "I'll never trust atoms. They make up everything!",
+        "categories": []
+    },
+    {
+        "id": 904,
+        "text": "I have a really funny joke about trickle-down economics, but there's no use in telling it because 99",
+        "categories": [
+            "Get",
+            "It.",
+            "Never",
+            "Of",
+            "Will",
+            "You"
+        ]
+    },
+    {
+        "id": 905,
+        "text": "I didn't understand why the frisbee kept getting bigger. Then it hit me.",
+        "categories": []
+    },
+    {
+        "id": 906,
+        "text": "I made a whopping six figures last year. I also was fired from the toy factory for being too slow.",
+        "categories": []
+    },
+    {
+        "id": 907,
+        "text": "A guy walked into a bar…then he was disqualified from the limbo contest.",
+        "categories": []
+    },
+    {
+        "id": 908,
+        "text": "I got an anonymous compliment about my parking skills today. It said, Parking fine.",
+        "categories": []
+    },
+    {
+        "id": 909,
+        "text": "The calendar's days are numbered. I'll start planning the funeral.",
+        "categories": []
+    },
+    {
+        "id": 910,
+        "text": "I shouldn't have poured my root beer into a square glass. I hate beer!",
+        "categories": []
+    },
+    {
+        "id": 911,
+        "text": "I used to fill my tires for free, but now it costs a dollar. I guess that's the inflation everyone's talking about.",
+        "categories": []
+    },
+    {
+        "id": 912,
+        "text": "I'm such a morning person that I don't even need an alarm clock. That and I drink a gallon of water before I go to bed.",
+        "categories": []
+    },
+    {
+        "id": 913,
+        "text": "What came first, the chicken or the egg? I just ordered both on Amazon, so I'll let you know.",
+        "categories": []
+    },
+    {
+        "id": 914,
+        "text": "I'm the best at putting leaves in boiling water. It's my special tea.",
+        "categories": []
+    },
+    {
+        "id": 915,
+        "text": "When I was younger, my parents told me I can be anyone I dreamed of becoming. Then I learned the hard way that identity theft is a crime.",
+        "categories": []
+    },
+    {
+        "id": 916,
+        "text": "Taylor Swift is immune to vampires. They know she has bad blood.",
+        "categories": []
+    },
+    {
+        "id": 917,
+        "text": "The bartender broke up with her boyfriend, but he convinced her to give him one more shot.",
+        "categories": []
+    },
+    {
+        "id": 918,
+        "text": "Did you hear about the new corduroy pillowcases? They're making headlines.",
+        "categories": []
+    },
+    {
+        "id": 919,
+        "text": "If the early bird catches the worm, call me a night owl because I prefer pancakes.",
+        "categories": []
+    },
+    {
+        "id": 920,
+        "text": "The waiter asked if I wanted a box for my leftovers, but I told him I'm not into fighting.",
+        "categories": []
+    },
+    {
+        "id": 921,
+        "text": "I accidentally took out my Blockbuster card at the bar. The bouncer said never mind.",
+        "categories": []
+    },
+    {
+        "id": 922,
+        "text": "In a job interview, they asked me if I can perform under pressure. I told them I don't know the lyrics.",
+        "categories": []
+    },
+    {
+        "id": 923,
+        "text": "This guy was fired for always sweeping girls off their feet. He was a super-aggressive janitor.",
+        "categories": []
+    },
+    {
+        "id": 924,
+        "text": "When two vegetarians get in a fight, is it still called beef?",
+        "categories": []
+    },
+    {
+        "id": 925,
+        "text": "I heard that 5/4 of people are bad at fractions.",
+        "categories": []
+    },
+    {
+        "id": 926,
+        "text": "I'm always getting sick during the week. I think I have a weekend immune system.",
+        "categories": []
+    },
+    {
+        "id": 927,
+        "text": "Did you hear the joke about déjà vu? Did you hear the joke about déjà vu?",
+        "categories": []
+    },
+    {
+        "id": 928,
+        "text": "Can a kangaroo jump higher than our house? Of course it can, a house can't jump!",
+        "categories": []
+    },
+    {
+        "id": 929,
+        "text": "Why does Peter Pan always fly? He Neverlands.",
+        "categories": []
+    },
+    {
+        "id": 930,
+        "text": "What do you write on a rabbit's birthday card? Hoppy Birthday!",
+        "categories": []
+    },
+    {
+        "id": 931,
+        "text": "Where do sick boats go to get better? The boat doc.",
+        "categories": []
+    },
+    {
+        "id": 932,
+        "text": "How does a banana answer a phone call? Yellow!",
+        "categories": []
+    },
+    {
+        "id": 933,
+        "text": "If it's raining cats and dogs, make sure you don't step in a poodle!",
+        "categories": []
+    },
+    {
+        "id": 934,
+        "text": "How does a bee brush its hair? It uses a honeycomb.",
+        "categories": []
+    },
+    {
+        "id": 935,
+        "text": "What animal is dishonest? A lion.",
+        "categories": []
+    },
+    {
+        "id": 936,
+        "text": "What has four wheels and flies? A garbage truck.",
+        "categories": []
+    },
+    {
+        "id": 937,
+        "text": "Where do young trees learn math? Elementree school.",
+        "categories": []
+    },
+    {
+        "id": 938,
+        "text": "What's a lazy kangaroo called? A pouch potato.",
+        "categories": []
+    },
+    {
+        "id": 939,
+        "text": "The finger was put in detention for always picking on the nose.",
+        "categories": []
+    },
+    {
+        "id": 940,
+        "text": "Mount Rushmore is the only rock group that doesn't sing or play musical instruments.",
+        "categories": []
+    },
+    {
+        "id": 941,
+        "text": "What do tacos say in church? Lettuce pray!",
+        "categories": [
+            "Cinco",
+            "De",
+            "Mayo"
+        ]
+    },
+    {
+        "id": 942,
+        "text": "What do Santa's elves learn in Kindergarten? The elphabet.",
+        "categories": []
+    },
+    {
+        "id": 943,
+        "text": "What's the difference between a crocodile and an alligator? You will see one in a while and one later.",
+        "categories": []
+    },
+    {
+        "id": 944,
+        "text": "What does a pampered cow make? Spoiled milk.",
+        "categories": []
+    },
+    {
+        "id": 945,
+        "text": "What's the Easter Bunny's favorite music genre? Hip-hop.",
+        "categories": []
+    },
+    {
+        "id": 946,
+        "text": "What is a pony with a sore throat called? A little hoarse.",
+        "categories": []
+    },
+    {
+        "id": 947,
+        "text": "Where do baby cats swim? The kitty pool.",
+        "categories": []
+    },
+    {
+        "id": 948,
+        "text": "How do astronauts organize a trip? They planet.",
+        "categories": []
+    },
+    {
+        "id": 949,
+        "text": "I have a joke about pizza, but it's really cheesy.",
+        "categories": []
+    },
+    {
+        "id": 950,
+        "text": "What do clouds wear? Thunderwear.",
+        "categories": []
+    },
+    {
+        "id": 951,
+        "text": "What's brown and sticky? A stick.",
+        "categories": []
+    },
+    {
+        "id": 952,
+        "text": "What game are tornadoes the best at? Twister.",
+        "categories": []
+    },
+    {
+        "id": 953,
+        "text": "Why do giants sound so smart? They use big words!",
+        "categories": []
+    },
+    {
+        "id": 954,
+        "text": "If a squirrel seems to like you, you must be a bit nutty.",
+        "categories": []
+    },
+    {
+        "id": 955,
+        "text": "What's a ghost's favorite fruit? Boo-berries!",
+        "categories": [
+            "Halloween"
+        ]
+    },
+    {
+        "id": 956,
+        "text": "What sound does the engine of a witch's vehicle make? Broooom broooom!",
+        "categories": []
+    },
+    {
+        "id": 957,
+        "text": "What's orange and sounds just like a parrot? A carrot.",
+        "categories": []
+    },
+    {
+        "id": 958,
+        "text": "Did you hear about the circus fire? It was in tents!",
+        "categories": []
+    },
+    {
+        "id": 959,
+        "text": "How do you catch a squirrel? Climb a tree and act like a nut!",
+        "categories": []
+    },
+    {
+        "id": 960,
+        "text": "Did you hear about the guy who invented Lifesavers? They say he made a mint!",
+        "categories": []
+    },
+    {
+        "id": 961,
+        "text": "I told my wife she should embrace her mistakes. She gave me a hug.",
+        "categories": []
+    },
+    {
+        "id": 962,
+        "text": "Why don't eggs tell jokes? They might crack up!",
+        "categories": []
+    },
+    {
+        "id": 963,
+        "text": "What did the big flower say to the little flower? Hi, bud!",
+        "categories": []
+    },
+    {
+        "id": 964,
+        "text": "I went to buy some camouflage pants, but I couldn't find any.",
+        "categories": []
+    },
+    {
+        "id": 965,
+        "text": "What did the grape say when it got stepped on? Nothing, it just let out a little wine.",
+        "categories": []
+    },
+    {
+        "id": 966,
+        "text": "I used to have a job at a calendar factory, but I got fired because I took a couple of days off.",
+        "categories": []
+    },
+    {
+        "id": 967,
+        "text": "What do you call a snowman with a six-pack? An abdominal snowman!",
+        "categories": []
+    },
+    {
+        "id": 968,
+        "text": "Why don't skeletons fight each other? They don't have the guts!",
+        "categories": []
+    },
+    {
+        "id": 969,
+        "text": "Did you hear about the restaurant on the moon? Great food, no atmosphere!",
+        "categories": []
+    },
+    {
+        "id": 970,
+        "text": "What did one wall say to the other wall? I'll meet you at the corner!",
+        "categories": []
+    },
+    {
+        "id": 971,
+        "text": "Why did the math book look sad? Because it had too many problems!",
+        "categories": []
+    },
+    {
+        "id": 972,
+        "text": "What did one hat say to the other hat? You stay here, I'll go on ahead!",
+        "categories": []
+    },
+    {
+        "id": 973,
+        "text": "Why did the coffee file a police report? It got mugged!",
+        "categories": []
+    },
+    {
+        "id": 974,
+        "text": "I was going to tell you a joke about time travel, but you didn't like it.",
+        "categories": []
+    },
+    {
+        "id": 975,
+        "text": "I used to be a baker, but I couldn't make enough dough.",
+        "categories": []
+    },
+    {
+        "id": 976,
+        "text": "Did you hear about the guy who got hit in the head with a can of soda? He was lucky it was a soft drink.",
+        "categories": []
+    },
+    {
+        "id": 977,
+        "text": "I'm writing a book about glue, but I'm stuck on the first chapter.",
+        "categories": []
+    },
+    {
+        "id": 978,
+        "text": "What did one plate whisper to the other plate? Dinner is on me.",
+        "categories": []
+    },
+    {
+        "id": 979,
+        "text": "Why did the golfer bring two pairs of pants? In case he got a hole in one.",
+        "categories": []
+    },
+    {
+        "id": 980,
+        "text": "Two sheep walk into a—baaaa.",
+        "categories": []
+    },
+    {
+        "id": 981,
+        "text": "Stop looking for the perfect match; use a lighter.",
+        "categories": []
+    },
+    {
+        "id": 982,
+        "text": "Try the seafood diet—you see food, then you eat it.",
+        "categories": []
+    },
+    {
+        "id": 983,
+        "text": "Did you hear the rumor about butter? Well, I'm not going to go spreading it!",
+        "categories": []
+    },
+    {
+        "id": 984,
+        "text": "What's Forrest Gump's password? 1forrest1",
+        "categories": []
+    },
+    {
+        "id": 985,
+        "text": "What state is known for its small drinks? Minnesota.",
+        "categories": []
+    },
+    {
+        "id": 986,
+        "text": "What does a nosey pepper do? It gets jalapeño business.",
+        "categories": []
+    },
+    {
+        "id": 987,
+        "text": "If two vegetarians get in an argument, is it still called beef?",
+        "categories": []
+    },
+    {
+        "id": 988,
+        "text": "I have a clean conscious—it's never been used.",
+        "categories": []
+    },
+    {
+        "id": 989,
+        "text": "I love telling Dad jokes. Sometimes, he even laughs.",
+        "categories": []
+    },
+    {
+        "id": 990,
+        "text": "Can a kangaroo jump higher than a house? Of course, houses can't jump.",
+        "categories": []
+    },
+    {
+        "id": 991,
+        "text": "Why did the scarecrow win an award? He was outstanding in his field.",
+        "categories": []
+    },
+    {
+        "id": 992,
+        "text": "What concert would cost only 45 cents? 50 Cent featuring Nickelback!",
+        "categories": []
+    },
+    {
+        "id": 993,
+        "text": "How many telemarketers does it take to change a light bulb? Only one, but he has to do it during dinner.",
+        "categories": []
+    },
+    {
+        "id": 994,
+        "text": "What are the strongest days of the week? Saturday and Sunday. All the others are weekdays.",
+        "categories": []
+    },
+    {
+        "id": 995,
+        "text": "What did the seal with one fin say to the shark? If seal is broken, do not consume.",
+        "categories": []
+    },
+    {
+        "id": 996,
+        "text": "How do you deal with a fear of speed bumps? You slowly get over it.",
+        "categories": []
+    },
+    {
+        "id": 997,
+        "text": "How do you measure the mass of an influencer's following? By Instagrams!",
+        "categories": []
+    },
+    {
+        "id": 998,
+        "text": "How do you stop a bull from charging? Cancel its credit card.",
+        "categories": []
+    },
+    {
+        "id": 999,
+        "text": "Am I the only man my wife has ever dated? Unfortunately, yes, she said the others were all nines or tens!",
+        "categories": []
+    },
+    {
+        "id": 1000,
+        "text": "What's the difference between a man's wallet before and after kids? There are pictures where the money used to be.",
+        "categories": []
+    },
+    {
+        "id": 1001,
+        "text": "I haven't spoken to my wife in four years. I thought it would be rude to interrupt her!",
+        "categories": []
+    },
+    {
+        "id": 1002,
+        "text": "I wish my gray hair started in Las Vegas because what happens in Vegas, stays in Vegas.",
+        "categories": []
+    },
+    {
+        "id": 1003,
+        "text": "How do you follow Will Smith in the Mud? Follow the fresh prints.",
+        "categories": []
+    },
+    {
+        "id": 1004,
+        "text": "My kid is blaming me for ruining their birthday. That's ridiculous, I didn't even know it was today!",
+        "categories": []
+    },
+    {
+        "id": 1005,
+        "text": "My kid gave me a 'World's Best Dad' mug. At least she inherited my sense of humor.",
+        "categories": []
+    },
+    {
+        "id": 1006,
+        "text": "When a toddler reaches the why? stage, it's like opening a bottle of champagne—once it's uncorked, there's no going back.",
+        "categories": []
+    },
+    {
+        "id": 1007,
+        "text": "What's 90 degrees but covered with ice? The North and South Poles.",
+        "categories": []
+    },
+    {
+        "id": 1008,
+        "text": "What happened when the blue ship and the red ship collided at sea? Their crews were marooned.",
+        "categories": []
+    },
+    {
+        "id": 1009,
+        "text": "What's the difference between the bird flu and the swine flu? One requires tweetment and the other an oinkment.",
+        "categories": []
+    },
+    {
+        "id": 1010,
+        "text": "What do you call a line of men waiting to get haircuts? A barberqueue.",
+        "categories": []
+    },
+    {
+        "id": 1011,
+        "text": "Why do seagulls fly over the sea? If they flew over the bay, they would be bagels.",
+        "categories": []
+    },
+    {
+        "id": 1012,
+        "text": "I'm thinking I should do lunges to stay in shape. That would be a big step forward.",
+        "categories": []
+    },
+    {
+        "id": 1013,
+        "text": "What did the baby corn say to the mama corn? Where's popcorn?",
+        "categories": []
+    },
+    {
+        "id": 1014,
+        "text": "What vegetable is cool, but not that cool? Radish.",
+        "categories": []
+    },
+    {
+        "id": 1015,
+        "text": "What do you call two monkeys who share an Amazon Prime account? Prime mates.",
+        "categories": []
+    },
+    {
+        "id": 1016,
+        "text": "You can't spell par entry without try.",
+        "categories": []
+    },
+    {
+        "id": 1017,
+        "text": "What do you call a beehive without an exit? Un-bee-lievable.",
+        "categories": []
+    },
+    {
+        "id": 1018,
+        "text": "Why did the football coach go to the bank? To get his quarter back.",
+        "categories": []
+    },
+    {
+        "id": 1019,
+        "text": "Why can't a leopard hide? He's always spotted.",
+        "categories": []
+    },
+    {
+        "id": 1020,
+        "text": "Air used to be free at the gas station, now it costs 2.50. You want to know why? Inflation.",
+        "categories": []
+    },
+    {
+        "id": 1021,
+        "text": "I tried to get a smart car the other day but they sold out too fast. Why? I guess I'm just a bit slow.",
+        "categories": []
+    },
+    {
+        "id": 1022,
+        "text": "Did you hear about the claustrophobic astronaut? He just wanted a bit more space.",
+        "categories": []
+    },
+    {
+        "id": 1023,
+        "text": "Why did the orange lose the race? It ran out of juice.",
+        "categories": []
+    },
+    {
+        "id": 1024,
+        "text": "How you fix a broken pumpkin? With a pumpkin patch.",
+        "categories": []
+    },
+    {
+        "id": 1025,
+        "text": "Why are fish so smart? They live in schools!",
+        "categories": []
+    },
+    {
+        "id": 1026,
+        "text": "What's the best thing about Switzerland? I don't know, but the flag is a big plus.",
+        "categories": []
+    },
+    {
+        "id": 1027,
+        "text": "Why did the man fall down the well? Because he couldn't see that well!",
+        "categories": []
+    },
+    {
+        "id": 1028,
+        "text": "Why do peppers make such good archers? Because they habanero.",
+        "categories": []
+    },
+    {
+        "id": 1029,
+        "text": "What did the sink tell the toilet? You look flushed!",
+        "categories": []
+    },
+    {
+        "id": 1030,
+        "text": "Where do boats go when they're sick? To the dock.",
+        "categories": []
+    },
+    {
+        "id": 1031,
+        "text": "What has ears but cannot hear? A cornfield!",
+        "categories": []
+    },
+    {
+        "id": 1032,
+        "text": "Can February March? No, but April May!",
+        "categories": []
+    },
+    {
+        "id": 1033,
+        "text": "Why was 6 afraid of 7? Because 7 ate nine!",
+        "categories": []
+    },
+    {
+        "id": 1034,
+        "text": "I'm so good at sleeping that I do it with my eyes closed.",
+        "categories": []
+    },
+    {
+        "id": 1035,
+        "text": "What do you call a pencil with two erasers? Pointless.",
+        "categories": []
+    },
+    {
+        "id": 1036,
+        "text": "Did you hear the one about the roof? Never mind, it's over your head.",
+        "categories": []
+    },
+    {
+        "id": 1037,
+        "text": "What's brown and sticky? A stick.",
+        "categories": []
+    },
+    {
+        "id": 1038,
+        "text": "I hated facial hair but then it grew on me.",
+        "categories": []
+    },
+    {
+        "id": 1039,
+        "text": "It really takes guts to be an organ donor.",
+        "categories": []
+    },
+    {
+        "id": 1040,
+        "text": "What did the plumber say to the singer? Nice pipes.",
+        "categories": []
+    },
+    {
+        "id": 1041,
+        "text": "I was going to tell a time-traveling joke, but you guys didn't like it.",
+        "categories": []
+    },
+    {
+        "id": 1042,
+        "text": "I ordered a chicken and an egg online. I'll let you know.",
+        "categories": []
+    },
+    {
+        "id": 1043,
+        "text": "I'm reading an anti-gravity book. I can't put it down!",
+        "categories": []
+    },
+    {
+        "id": 1044,
+        "text": "I'd avoid the sushi if I were you. It's a little fishy!",
+        "categories": []
+    },
+    {
+        "id": 1045,
+        "text": "What do houses wear? An address.",
+        "categories": []
+    },
+    {
+        "id": 1046,
+        "text": "What did the two pieces of bread say on their wedding day? It was loaf at first sight.",
+        "categories": []
+    },
+    {
+        "id": 1047,
+        "text": "What kind of shoes does a lazy person wear? Loafers.",
+        "categories": []
+    },
+    {
+        "id": 1048,
+        "text": "What did the ocean say to the beach? Nothing, it just waved.",
+        "categories": []
+    },
+    {
+        "id": 1049,
+        "text": "What happens when a snowman throws a tantrum? He has a meltdown.",
+        "categories": []
+    },
+    {
+        "id": 1050,
+        "text": "Why'd the fisherman order the halibut? Just for the halibut!",
+        "categories": []
+    },
+    {
+        "id": 1051,
+        "text": "Why is Peter Pan always flying? Because he Neverlands.",
+        "categories": []
+    },
+    {
+        "id": 1052,
+        "text": "What do you call a sleeping bull? A bulldozer.",
+        "categories": []
+    },
+    {
+        "id": 1053,
+        "text": "How do you throw a party in outer space? You planet.",
+        "categories": []
+    },
+    {
+        "id": 1054,
+        "text": "Why was the broom late to class? It over-swept.",
+        "categories": []
+    },
+    {
+        "id": 1055,
+        "text": "How do you make an octopus laugh? With ten-tickles!",
+        "categories": []
+    },
+    {
+        "id": 1056,
+        "text": "What do you say to a rabbit on its birthday? Hoppy Birthday!",
+        "categories": []
+    },
+    {
+        "id": 1057,
+        "text": "What type of tree fits in your hand? A palm tree.",
+        "categories": []
+    },
+    {
+        "id": 1058,
+        "text": "Why couldn't the bicycle stand up by itself? It was two tired!",
+        "categories": []
+    },
+    {
+        "id": 1059,
+        "text": "Wanna hear a joke about construction? I'm still workin' on it!",
+        "categories": []
+    },
+    {
+        "id": 1060,
+        "text": "What do you call a fake noodle? An impasta.",
+        "categories": []
+    },
+    {
+        "id": 1061,
+        "text": "How does a lawyer say goodbye? I'll be suing ya!",
+        "categories": []
+    },
+    {
+        "id": 1062,
+        "text": "You can't trust atoms. They make up everything!",
+        "categories": []
+    },
+    {
+        "id": 1063,
+        "text": "What made the tomato blush? It saw the salad dressing.",
+        "categories": []
+    },
+    {
+        "id": 1064,
+        "text": "Can I dive in this pool? It deep-ends.",
+        "categories": []
+    },
+    {
+        "id": 1065,
+        "text": "What did the buffalo say to its son when he left? Bison!",
+        "categories": []
+    },
+    {
+        "id": 1066,
+        "text": "Why do vampires always seem sick? They're coffin.",
+        "categories": [
+            "Halloween"
+        ]
+    },
+    {
+        "id": 1067,
+        "text": "What musical instrument do you find in the bathroom? A tuba toothpaste!",
+        "categories": []
+    },
+    {
+        "id": 1068,
+        "text": "Which state has the most streets? Rhode Island.",
+        "categories": []
+    },
+    {
+        "id": 1069,
+        "text": "How do astronomers organize a party? They planet.",
+        "categories": []
+    },
+    {
+        "id": 1070,
+        "text": "Why do bees have sticky hair? Because they use a honeycomb.",
+        "categories": []
+    },
+    {
+        "id": 1071,
+        "text": "Why do melons have weddings? They cantaloupe!",
+        "categories": []
+    },
+    {
+        "id": 1072,
+        "text": "What did the police officer say to her belly button? You're under a vest!",
+        "categories": []
+    },
+    {
+        "id": 1073,
+        "text": "What do you call a fibbing cat? A lion.",
+        "categories": []
+    },
+    {
+        "id": 1074,
+        "text": "If a child refuses to nap, are they guilty of resisting a rest?",
+        "categories": []
+    },
+    {
+        "id": 1075,
+        "text": "Did you hear about the outlet who got in a fight with the power cord? He thought he could socket to him.",
+        "categories": []
+    },
+    {
+        "id": 1076,
+        "text": "What do you call a fancy fish? So-fish-ticated.",
+        "categories": []
+    },
+    {
+        "id": 1077,
+        "text": "If April showers bring May flowers, what do May flowers bring? Pilgrims.",
+        "categories": []
+    },
+    {
+        "id": 1078,
+        "text": "How do you make 7 even? You take away the s.",
+        "categories": []
+    },
+    {
+        "id": 1079,
+        "text": "What kind of cars do eggs drive? Yolkswagens.",
+        "categories": []
+    },
+    {
+        "id": 1080,
+        "text": "Where do math teachers go on vacation? Times Square.",
+        "categories": []
+    },
+    {
+        "id": 1081,
+        "text": "Why was the stadium so hot after the game? Because all the fans left.",
+        "categories": []
+    },
+    {
+        "id": 1082,
+        "text": "The coach went to the bank to get his quarterback.",
+        "categories": []
+    },
+    {
+        "id": 1083,
+        "text": "I asked my dog what's two minus two. He said nothing.",
+        "categories": []
+    },
+    {
+        "id": 1084,
+        "text": "The first thing Santa's elves learn in school is their elf-abet.",
+        "categories": [
+            "Christmas"
+        ]
+    },
+    {
+        "id": 1085,
+        "text": "Ghosts are bad liars because you can see right through them.",
+        "categories": [
+            "Halloween"
+        ]
+    },
+    {
+        "id": 1086,
+        "text": "Shouldn't the roof of your mouth actually be called the ceiling?",
+        "categories": []
+    },
+    {
+        "id": 1087,
+        "text": "All vampires keep their money in a special place—the blood bank.",
+        "categories": []
+    },
+    {
+        "id": 1088,
+        "text": "The pony couldn't sing because it was a little horse.",
+        "categories": []
+    },
+    {
+        "id": 1089,
+        "text": "RIP boiling water, you will be mist.",
+        "categories": []
+    },
+    {
+        "id": 1090,
+        "text": "I told my doctor I heard buzzing, but she said it's just a bug that's going around.",
+        "categories": []
+    },
+    {
+        "id": 1091,
+        "text": "I ate a clock the other day. It was very time consuming.",
+        "categories": []
+    },
+    {
+        "id": 1092,
+        "text": "I once wrote a song about a tortilla, but it's more of a wrap.",
+        "categories": []
+    },
+    {
+        "id": 1093,
+        "text": "You can tell it's a dogwood tree from its bark.",
+        "categories": []
+    },
+    {
+        "id": 1094,
+        "text": "When does a joke turn into a dad joke? When it becomes apparent.",
+        "categories": []
+    },
+    {
+        "id": 1095,
+        "text": "They say that 3/2 people are bad at fractions.",
+        "categories": []
+    },
+    {
+        "id": 1096,
+        "text": "Dogs can't operate MRI machines but catscan.",
+        "categories": []
+    },
+    {
+        "id": 1097,
+        "text": "A witch's vehicle goes brrrroom brrrroom!",
+        "categories": []
+    },
+    {
+        "id": 1098,
+        "text": "I'm worried for the calendar because its days are numbered.",
+        "categories": []
+    },
+    {
+        "id": 1099,
+        "text": "Dear Math, it's time to grow up and solve your own problems.",
+        "categories": []
+    },
+    {
+        "id": 1100,
+        "text": "I only know 25 letters of the alphabet—I don't know y.",
+        "categories": []
+    },
+    {
+        "id": 1101,
+        "text": "I just don't trust stairs, they're always up to something.",
+        "categories": []
+    },
+    {
+        "id": 1102,
+        "text": "I used to play piano by ear, but now I use my hands.",
+        "categories": []
+    },
+    {
+        "id": 1103,
+        "text": "How do celebrities stay cool? They have many fans.",
+        "categories": []
+    },
+    {
+        "id": 1104,
+        "text": "Why did the picture go to prison? Because it was framed.",
+        "categories": []
+    },
+    {
+        "id": 1105,
+        "text": "How does a hurricane see? With one eye.",
+        "categories": []
+    },
+    {
+        "id": 1106,
+        "text": "Where do polar bears keep their money? The snow bank.",
+        "categories": []
+    },
+    {
+        "id": 1107,
+        "text": "What's a tornado's favorite game? Twister!",
+        "categories": []
+    },
+    {
+        "id": 1108,
+        "text": "How does the moon cut his hair? Eclipse it.",
+        "categories": []
+    },
+    {
+        "id": 1109,
+        "text": "What do you call a funny mountain? Hill-arious.",
+        "categories": []
+    },
+    {
+        "id": 1110,
+        "text": "What gets wetter the more it dries? A towel.",
+        "categories": []
+    },
+    {
+        "id": 1111,
+        "text": "What did the banana say to the boy? Nothing, bananas can't talk!",
+        "categories": []
+    },
+    {
+        "id": 1112,
+        "text": "What rock group has four men who don't sing? Mount Rushmore.",
+        "categories": []
+    },
+    {
+        "id": 1113,
+        "text": "My boss told me to have a good day, so I went home!",
+        "categories": []
+    },
+    {
+        "id": 1114,
+        "text": "What do you call cheese that isn't yours? Nacho cheese.",
+        "categories": []
+    },
+    {
+        "id": 1115,
+        "text": "Did you get your haircut? No, I got them all cut.",
+        "categories": []
+    },
+    {
+        "id": 1116,
+        "text": "I was wondering why the frisbee kept getting bigger and bigger. Then it hit me.",
+        "categories": []
+    },
+    {
+        "id": 1117,
+        "text": "Wanna hear a joke about paper? Never mind. It's tearable.",
+        "categories": []
+    },
+    {
+        "id": 1118,
+        "text": "How many apples grow on a tree? All of them!",
+        "categories": []
+    },
+    {
+        "id": 1119,
+        "text": "I talk to myself because sometimes I just need expert advice.",
+        "categories": []
+    },
+    {
+        "id": 1120,
+        "text": "I used to be addicted to the hokey-pokey until I turned myself around.",
+        "categories": []
+    },
+    {
+        "id": 1121,
+        "text": "What do you call someone who tells dad jokes but isn't a dad? A faux pa.",
+        "categories": []
+    },
+    {
+        "id": 1122,
+        "text": "I could tell a joke about pizza, but it's a little cheesy.",
+        "categories": []
+    },
+    {
+        "id": 1123,
+        "text": "If you see a crime at an Apple store, are you an iWitness?",
+        "categories": []
+    },
+    {
+        "id": 1124,
+        "text": "I hate Velcro. It's a rip off.",
+        "categories": []
+    },
+    {
+        "id": 1125,
+        "text": "Spring is here! I got so excited that I wet my plants.",
+        "categories": []
+    },
+    {
+        "id": 1126,
+        "text": "I had to sell my vacuum cleaner. All it was doing was gathering dust.",
+        "categories": []
+    },
+    {
+        "id": 1127,
+        "text": "Do you know how many people are dead at a cemetery? All of them.",
+        "categories": []
+    },
+    {
+        "id": 1128,
+        "text": "I'll call you later. Don't call me later, call me Dad.",
+        "categories": []
+    },
+    {
+        "id": 1129,
+        "text": "If the early bird gets the worm, I'll sleep in until there's pancakes.",
+        "categories": []
+    },
+    {
+        "id": 1130,
+        "text": "The wedding was so beautiful, even the cake was in tiers.",
+        "categories": []
+    },
+    {
+        "id": 1131,
+        "text": "Why are spiders so smart? They can find everything on the web.",
+        "categories": []
+    },
+    {
+        "id": 1132,
+        "text": "What do you call a toothless bear? A gummy bear!",
+        "categories": []
+    },
+    {
+        "id": 1133,
+        "text": "What do you give a sick lemon? Lemon-aid.",
+        "categories": []
+    },
+    {
+        "id": 1134,
+        "text": "What did the nose tell the finger? Stop picking on me!",
+        "categories": []
+    },
+    {
+        "id": 1135,
+        "text": "Why can't your hand be 12 inches long? Because then it would be a foot.",
+        "categories": []
+    },
+    {
+        "id": 1136,
+        "text": "What kind of car does a sheep like to drive? A lamborghini.",
+        "categories": []
+    },
+    {
+        "id": 1137,
+        "text": "What key is used to open bananas? A mon-key.",
+        "categories": []
+    },
+    {
+        "id": 1138,
+        "text": "What has four wheels and flies? A garbage truck.",
+        "categories": []
+    },
+    {
+        "id": 1139,
+        "text": "How do you talk to a giant? You use big words!",
+        "categories": []
+    },
+    {
+        "id": 1140,
+        "text": "How do you make a tissue dance? Put a little boogie in it!",
+        "categories": []
+    },
+    {
+        "id": 1141,
+        "text": "What kind of milk comes from a pampered cow? Spoiled milk.",
+        "categories": []
+    },
+    {
+        "id": 1142,
+        "text": "What's a sea monster's favorite lunch? Fish and ships.",
+        "categories": []
+    },
+    {
+        "id": 1143,
+        "text": "What do you call an alligator in a vest? An investigator.",
+        "categories": []
+    },
+    {
+        "id": 1144,
+        "text": "Why are pigs so bad at sports? They always hog the ball.",
+        "categories": []
+    },
+    {
+        "id": 1145,
+        "text": "Why shouldn't you tell an egg a joke? It'll crack up.",
+        "categories": []
+    },
+    {
+        "id": 1146,
+        "text": "What's a foot long and slippery? A slipper.",
+        "categories": []
+    },
+    {
+        "id": 1147,
+        "text": "What's a ninja's favorite type of shoes? Sneakers!",
+        "categories": []
+    },
+    {
+        "id": 1148,
+        "text": "What's orange and sounds like a parrot? A carrot!",
+        "categories": []
+    },
+    {
+        "id": 1149,
+        "text": "How does a penguin build a house? Igloos it together.",
+        "categories": []
+    },
+    {
+        "id": 1150,
+        "text": "Why is no one friends with Dracula? He's a pain in the neck.",
+        "categories": []
+    },
+    {
+        "id": 1151,
+        "text": "Where do you learn all about ice cream? Sundae school.",
+        "categories": []
+    },
+    {
+        "id": 1152,
+        "text": "Which bear is the most condescending? A pan-duh!",
+        "categories": []
+    },
+    {
+        "id": 1153,
+        "text": "What kind of noise does a witch's vehicle make? Brrrroooom, brrroooom.",
+        "categories": []
+    },
+    {
+        "id": 1154,
+        "text": "What's brown and sticky? A stick.",
+        "categories": []
+    },
+    {
+        "id": 1155,
+        "text": "Two guys walked into a bar. The third guy ducked.",
+        "categories": []
+    },
+    {
+        "id": 1156,
+        "text": "Did you hear about the actor who broke his leg onstage? He's still in the cast.",
+        "categories": []
+    },
+    {
+        "id": 1157,
+        "text": "How do you get a country girl's attention? A tractor.",
+        "categories": []
+    },
+    {
+        "id": 1158,
+        "text": "Why did the pharmacist walk on her tiptoes? She didn't want to wake the sleeping pills.",
+        "categories": []
+    },
+    {
+        "id": 1159,
+        "text": "I wanted to buy a pair of camouflage pants, but I couldn't find any.",
+        "categories": []
+    },
+    {
+        "id": 1160,
+        "text": "Why are elevator jokes so classic and good? They work on many levels.",
+        "categories": []
+    },
+    {
+        "id": 1161,
+        "text": "I have an inferiority complex, but it's not a very good one.",
+        "categories": []
+    },
+    {
+        "id": 1162,
+        "text": "What do you call a pudgy psychic? A four-chin teller.",
+        "categories": []
+    },
+    {
+        "id": 1163,
+        "text": "I had a date last night and it was perfect. Tomorrow, I'll have a fig.",
+        "categories": []
+    },
+    {
+        "id": 1164,
+        "text": "What did the police officer say to his belly-button? You're under a vest.",
+        "categories": []
+    },
+    {
+        "id": 1165,
+        "text": "What do you call it when a group of apes starts a company? Monkey business.",
+        "categories": []
+    },
+    {
+        "id": 1166,
+        "text": "My wife asked me to stop singing Wonderwall to her. I said Maybe...",
+        "categories": []
+    },
+    {
+        "id": 1167,
+        "text": "What kind of drink can be bitter and sweet? Reali-tea.",
+        "categories": []
+    },
+    {
+        "id": 1168,
+        "text": "What do you call a naughty lamb dressed up like a skeleton for Halloween? Baaad to the bone.",
+        "categories": []
+    },
+    {
+        "id": 1169,
+        "text": "Why did the lobster blush? Because it saw the ocean's bottom!",
+        "categories": []
+    },
+    {
+        "id": 1170,
+        "text": "Want to know why nurses like red crayons? Sometimes they have to draw blood.",
+        "categories": []
+    },
+    {
+        "id": 1171,
+        "text": "What would the Terminator be called in his retirement? The Exterminator.",
+        "categories": []
+    },
+    {
+        "id": 1172,
+        "text": "What did Tennessee? The same thing as Arkansas.",
+        "categories": []
+    },
+    {
+        "id": 1173,
+        "text": "My wife asked me to go get 6 cans of Sprite from the grocery store. I realized when I got home that I had picked 7 up.",
+        "categories": []
+    },
+    {
+        "id": 1174,
+        "text": "Why do bees have sticky hair? Because they use a honeycomb.",
+        "categories": []
+    },
+    {
+        "id": 1175,
+        "text": "Why do some couples go to the gym? Because they want their relationship to work out.",
+        "categories": []
+    },
+    {
+        "id": 1176,
+        "text": "What do you call an angry musician flipping someone off? A song bird.",
+        "categories": []
+    },
+    {
+        "id": 1177,
+        "text": "Did you hear about the kidnapping at school? It's fine, he woke up.",
+        "categories": []
+    },
+    {
+        "id": 1178,
+        "text": "How can you tell it's a dogwood tree? By the bark.",
+        "categories": []
+    },
+    {
+        "id": 1179,
+        "text": "My boss told me to have a good day, so I went home.",
+        "categories": []
+    },
+    {
+        "id": 1180,
+        "text": "Our vacuum cleaner is getting old. It's just gathering dust.",
+        "categories": []
+    },
+    {
+        "id": 1181,
+        "text": "Why did the man fall down the well? Because he couldn't see that well.",
+        "categories": []
+    },
+    {
+        "id": 1182,
+        "text": "Why is Peter Pan always flying? Because he Neverlands.",
+        "categories": []
+    },
+    {
+        "id": 1183,
+        "text": "Which state has the most streets? Rhode Island.",
+        "categories": []
+    },
+    {
+        "id": 1184,
+        "text": "What do you call 26 letters that went for a swim? Alphawetical.",
+        "categories": []
+    },
+    {
+        "id": 1185,
+        "text": "What's the name of a very polite, European body of water? Merci.",
+        "categories": []
+    },
+    {
+        "id": 1186,
+        "text": "Why was the color green notoriously single? It was always so jaded.",
+        "categories": []
+    },
+    {
+        "id": 1187,
+        "text": "I used to hate facial hair, but then it grew on me.",
+        "categories": []
+    },
+    {
+        "id": 1188,
+        "text": "I want to make a brief joke, but it's a little cheesy.",
+        "categories": []
+    },
+    {
+        "id": 1189,
+        "text": "Why did the coach go to the bank? To get his quarter back.",
+        "categories": []
+    },
+    {
+        "id": 1190,
+        "text": "How do celebrities stay cool? They have many fans.",
+        "categories": []
+    },
+    {
+        "id": 1191,
+        "text": "Sundays are always a little sad, but the day before is a sadder day.",
+        "categories": []
+    },
+    {
+        "id": 1192,
+        "text": "5/4 of people admit they're bad at fractions.",
+        "categories": []
+    },
+    {
+        "id": 1193,
+        "text": "Why did the bedding hide their relationship? They just wanted something pillow-key!",
+        "categories": []
+    },
+    {
+        "id": 1194,
+        "text": "You're American when you go into a bathroom and when you come out, but what are you while you're in the bathroom? European.",
+        "categories": []
+    },
+    {
+        "id": 1195,
+        "text": "I've been thinking about taking up meditation. I figure it's better than sitting around doing nothing.",
+        "categories": []
+    },
+    {
+        "id": 1196,
+        "text": "What did the flowers do when the bride walked down the aisle? They rose.",
+        "categories": []
+    },
+    {
+        "id": 1197,
+        "text": "It takes guts to be an organ donor.",
+        "categories": []
+    },
+    {
+        "id": 1198,
+        "text": "What do you get from a pampered cow? Spoiled milk.",
+        "categories": []
+    },
+    {
+        "id": 1199,
+        "text": "What does Rockin' Robin do when she's bored? Tweet.",
+        "categories": []
+    },
+    {
+        "id": 1200,
+        "text": "I lost my job at the bank on my first day. A woman asked me to check her balance, so I pushed her over.",
+        "categories": []
+    },
+    {
+        "id": 1201,
+        "text": "Why did Waldo go to therapy? Because he needed to find himself.",
+        "categories": []
+    },
+    {
+        "id": 1202,
+        "text": "How do you row a canoe filled with puppies? Bring out the doggy paddle.",
+        "categories": []
+    },
+    {
+        "id": 1203,
+        "text": "Singing in the shower is fun until you get soap in your mouth. Then it becomes a soap opera.",
+        "categories": []
+    },
+    {
+        "id": 1204,
+        "text": "Why were the utensils stuck together? They were spooning.",
+        "categories": []
+    },
+    {
+        "id": 1205,
+        "text": "What's a crafty dancer's favorite hobby? Cutting a rug.",
+        "categories": []
+    },
+    {
+        "id": 1206,
+        "text": "How does a penguin build his house? Igloos it together.",
+        "categories": []
+    },
+    {
+        "id": 1207,
+        "text": "What kind of music do chiropractors like? Hip pop.",
+        "categories": []
+    },
+    {
+        "id": 1208,
+        "text": "Where do you learn to make ice cream? At sundae school.",
+        "categories": []
+    },
+    {
+        "id": 1209,
+        "text": "What kind of shoes does a lazy person wear? Loafers.",
+        "categories": []
+    },
+    {
+        "id": 1210,
+        "text": "Why is cold water so insecure? Because it's never called hot.",
+        "categories": []
+    },
+    {
+        "id": 1211,
+        "text": "Justice is a dish best served cold. If it were served warm, it would be just-water.",
+        "categories": []
+    },
+    {
+        "id": 1212,
+        "text": "I was going to tell a time-traveling joke, but you guys didn't like it.",
+        "categories": []
+    },
+    {
+        "id": 1213,
+        "text": "Shouldn't the roof of your mouth actually be called the ceiling?",
+        "categories": []
+    },
+    {
+        "id": 1214,
+        "text": "Why did the baby strawberry cry? Because its mother was in a jam.",
+        "categories": []
+    },
+    {
+        "id": 1215,
+        "text": "Why couldn't the toilet paper cross the road? Because it got stuck in a crack.",
+        "categories": [
+            "Cross",
+            "Road",
+            "The"
+        ]
+    },
+    {
+        "id": 1216,
+        "text": "Stop looking for the perfect match…use a lighter.",
+        "categories": []
+    },
+    {
+        "id": 1217,
+        "text": "I told my doctor I heard buzzing, but he said it's just a bug going around.",
+        "categories": []
+    },
+    {
+        "id": 1218,
+        "text": "What kind of car does a sheep like to drive? A Lamborghini.",
+        "categories": []
+    },
+    {
+        "id": 1219,
+        "text": "What do you call someone who won't stick to a diet? A desserter.",
+        "categories": []
+    },
+    {
+        "id": 1220,
+        "text": "What did the accountant say while auditing a document? This is taxing.",
+        "categories": []
+    },
+    {
+        "id": 1221,
+        "text": "What did the two pieces of bread say on their wedding day? It was loaf at first sight.",
+        "categories": []
+    },
+    {
+        "id": 1222,
+        "text": "If you see a burglary at an Apple store, you become an iWitness.",
+        "categories": []
+    },
+    {
+        "id": 1223,
+        "text": "If the early bird gets the worm, I'll sleep in until there's pancakes.",
+        "categories": []
+    },
+    {
+        "id": 1224,
+        "text": "Why do melons have weddings? Because they cantaloupe.",
+        "categories": []
+    },
+    {
+        "id": 1225,
+        "text": "I signed up for a marathon, but how will I know if it's the real deal or just a run through?",
+        "categories": []
+    },
+    {
+        "id": 1226,
+        "text": "When you have a bladder infection, urine trouble.",
+        "categories": []
+    },
+    {
+        "id": 1227,
+        "text": "What did the drummer call his twin daughters? Anna One, Anna Two!",
+        "categories": []
+    },
+    {
+        "id": 1228,
+        "text": "What did the juicer say to the orange during self-quarantine? Can't wait to squeeze you!",
+        "categories": []
+    },
+    {
+        "id": 1229,
+        "text": "What do you call a toothless bear? A gummy bear!",
+        "categories": []
+    },
+    {
+        "id": 1230,
+        "text": "Want to hear a joke about construction? I'm still working on it.",
+        "categories": []
+    },
+    {
+        "id": 1231,
+        "text": "Someone told me that I should write a book. I said, That's a novel concept.",
+        "categories": []
+    },
+    {
+        "id": 1232,
+        "text": "Two goldfish are in a tank. One says to the other, Do you know how to drive this thing?",
+        "categories": []
+    },
+    {
+        "id": 1233,
+        "text": "Why did the pony ask for a glass of water? Because it was a little horse.",
+        "categories": []
+    },
+    {
+        "id": 1234,
+        "text": "What's Forrest Gump's password? 1forrest1",
+        "categories": []
+    },
+    {
+        "id": 1235,
+        "text": "I tell dad jokes, but I don't have any kids. I'm a faux pa.",
+        "categories": []
+    },
+    {
+        "id": 1236,
+        "text": "What does a nosey pepper do? It gets jalapeño business.",
+        "categories": []
+    },
+    {
+        "id": 1237,
+        "text": "How can you mend a broken pumpkin? Use a pumpkin patch.",
+        "categories": []
+    },
+    {
+        "id": 1238,
+        "text": "If a child refuses to nap, are they guilty of resisting a rest?",
+        "categories": []
+    },
+    {
+        "id": 1239,
+        "text": "Why do dads feel the need to tell such bad jokes? They just want to help you become a groan up.",
+        "categories": []
+    },
+    {
+        "id": 1240,
+        "text": "I know a lot of jokes about retired people, but none of them work.",
+        "categories": []
+    },
+    {
+        "id": 1241,
+        "text": "Why are spiders so smart? They can find everything on the web.",
+        "categories": []
+    },
+    {
+        "id": 1242,
+        "text": "What do you call spiders who just got married? Newly-webs.",
+        "categories": []
+    },
+    {
+        "id": 1243,
+        "text": "RIP boiled water—you will be mist.",
+        "categories": []
+    },
+    {
+        "id": 1244,
+        "text": "What do you call two octopuses that look the same? Itenticle.",
+        "categories": []
+    },
+    {
+        "id": 1245,
+        "text": "What has one head, one foot, and four legs? A bed.",
+        "categories": []
+    },
+    {
+        "id": 1246,
+        "text": "Sore throats are a pain in the neck.",
+        "categories": []
+    },
+    {
+        "id": 1247,
+        "text": "What does a house wear? Address.",
+        "categories": []
+    },
+    {
+        "id": 1248,
+        "text": "Why did the scarecrow win an award? He was out standing in his field.",
+        "categories": []
+    },
+    {
+        "id": 1249,
+        "text": "What is a scarecrow's favorite fruit? Straw-berries.",
+        "categories": []
+    },
+    {
+        "id": 1250,
+        "text": "What's red and smells like blue paint? Red paint.",
+        "categories": []
+    },
+    {
+        "id": 1251,
+        "text": "My son asked me to put his shoes on, but I don't think they'll fit me.",
+        "categories": []
+    },
+    {
+        "id": 1252,
+        "text": "I've been bored recently, so I decided to take up fencing. The neighbors keep demanding that I put it back.",
+        "categories": []
+    },
+    {
+        "id": 1253,
+        "text": "How do you know when a chicken is evil? It lays deviled eggs.",
+        "categories": []
+    },
+    {
+        "id": 1254,
+        "text": "What do you call an unpredictable camera? A loose Canon.",
+        "categories": []
+    },
+    {
+        "id": 1255,
+        "text": "I didn't get a haircut, I got them all cut.",
+        "categories": []
+    },
+    {
+        "id": 1256,
+        "text": "Which U.S. state is known for its especially small soft drinks? Minnesota.",
+        "categories": []
+    },
+    {
+        "id": 1257,
+        "text": "What do sprinters eat before a race? Nothing—they fast.",
+        "categories": []
+    },
+    {
+        "id": 1258,
+        "text": "What did one Dorito farmer say to the other? Cool Ranch!",
+        "categories": []
+    },
+    {
+        "id": 1259,
+        "text": "How do cows shop? From cattle-logs.",
+        "categories": []
+    },
+    {
+        "id": 1260,
+        "text": "I'm so good at sleeping, I can do it with my eyes closed.",
+        "categories": []
+    },
+    {
+        "id": 1261,
+        "text": "People are usually shocked that I have a Police record. But I love their greatest hits!",
+        "categories": []
+    },
+    {
+        "id": 1262,
+        "text": "I told my girlfriend she drew on her eyebrows too high. She seemed surprised.",
+        "categories": []
+    },
+    {
+        "id": 1263,
+        "text": "What do you call a fibbing cat? A lion.",
+        "categories": []
+    },
+    {
+        "id": 1264,
+        "text": "Why shouldn't you write with a broken pencil? Because it's pointless.",
+        "categories": []
+    },
+    {
+        "id": 1265,
+        "text": "I like telling Dad jokes…sometimes he laughs.",
+        "categories": []
+    },
+    {
+        "id": 1266,
+        "text": "How do you weigh a millennial? In Instagrams.",
+        "categories": []
+    },
+    {
+        "id": 1267,
+        "text": "The wedding was so beautiful, even the cake was in tiers.",
+        "categories": []
+    },
+    {
+        "id": 1268,
+        "text": "What's the most patriotic sport? Flag football.",
+        "categories": []
+    },
+    {
+        "id": 1269,
+        "text": "Why were spectators confused by the koala's self-portrait? It was bear.",
+        "categories": []
+    },
+    {
+        "id": 1270,
+        "text": "Why did the envelope take so long to get ready? It had to get addressed.",
+        "categories": []
+    },
+    {
+        "id": 1271,
+        "text": "What does a karate master get rewarded with while driving? A seat belt.",
+        "categories": []
+    },
+    {
+        "id": 1272,
+        "text": "What do you call a baby sheep that knows karate? A lamb chop.",
+        "categories": []
+    },
+    {
+        "id": 1273,
+        "text": "What did the husband say to his wife right after getting LASIK surgery? Aren't you a sight for sore eyes?",
+        "categories": []
+    },
+    {
+        "id": 1274,
+        "text": "Why are pigs bad drivers? Because they hog the road.",
+        "categories": []
+    },
+    {
+        "id": 1275,
+        "text": "What do lions use to look at their manes? Mirroars.",
+        "categories": []
+    },
+    {
+        "id": 1276,
+        "text": "What did the dad say when his golden retriever was caught eating a hot dog? It's a dog eat dog world out there.",
+        "categories": []
+    },
+    {
+        "id": 1277,
+        "text": "Do mascara and lipstick ever argue? Sure, but then they makeup.",
+        "categories": []
+    },
+    {
+        "id": 1278,
+        "text": "What piece on the playground is always exhausted? The tire swing.",
+        "categories": []
+    },
+    {
+        "id": 1279,
+        "text": "Why did two tall people get along so well? They could really see eye to eye.",
+        "categories": []
+    },
+    {
+        "id": 1280,
+        "text": "Why was the gossip disliked at the coffee shop? She always spilled the tea.",
+        "categories": []
+    },
+    {
+        "id": 1281,
+        "text": "What does a writer have in common with a football player? Anxiety over a rough draft.",
+        "categories": []
+    },
+    {
+        "id": 1282,
+        "text": "Where do wasps like to get lunch? A bee-stro.",
+        "categories": []
+    },
+    {
+        "id": 1283,
+        "text": "Is there anything worse than when it's raining cats and dogs? Yes! Hailing taxis.",
+        "categories": []
+    },
+    {
+        "id": 1284,
+        "text": "Why would doors do well on social media? Everyone looks for their handles.",
+        "categories": []
+    },
+    {
+        "id": 1285,
+        "text": "Why did the physicist and the biologist break up? Because they had no chemistry.",
+        "categories": []
+    },
+    {
+        "id": 1286,
+        "text": "If you feel like someone is watching you, you're not alone.",
+        "categories": []
+    },
+    {
+        "id": 1287,
+        "text": "Which bathroom appliance would be the worst life preserver? The sink.",
+        "categories": []
+    },
+    {
+        "id": 1288,
+        "text": "Why was the dad sitting on a pack of playing cards? His kid asked him to sit on the deck.",
+        "categories": []
+    },
+    {
+        "id": 1289,
+        "text": "How do birds learn how to fly? They wing it!",
+        "categories": []
+    },
+    {
+        "id": 1290,
+        "text": "What kind of bird is always getting hurt? The owl.",
+        "categories": []
+    },
+    {
+        "id": 1291,
+        "text": "What's either a really gross animal issue OR an impressive, magical school? Hogwarts.",
+        "categories": []
+    },
+    {
+        "id": 1292,
+        "text": "How does Darth Vader like his toast? On the dark side.",
+        "categories": []
+    },
+    {
+        "id": 1293,
+        "text": "What did the dishwasher say to the oven after a productive day? You've been on fire!",
+        "categories": []
+    },
+    {
+        "id": 1294,
+        "text": "Why did the tomato blush? Because it saw the salad dressing.",
+        "categories": []
+    },
+    {
+        "id": 1295,
+        "text": "Why did the cashier rip money in half? They were asked to break a bill.",
+        "categories": []
+    },
+    {
+        "id": 1296,
+        "text": "What did one furniture maker say to another during a tense discussion? Let's table this.",
+        "categories": []
+    },
+    {
+        "id": 1297,
+        "text": "I was going to tell a joke about water, but it was too tasteless.",
+        "categories": []
+    },
+    {
+        "id": 1298,
+        "text": "Why couldn't the duck be quiet? Because it was addicted to quack.",
+        "categories": []
+    },
+    {
+        "id": 1299,
+        "text": "Why was the ghost so tired? He worked the graveyard shift.",
+        "categories": [
+            "Halloween"
+        ]
+    },
+    {
+        "id": 1300,
+        "text": "Why do pancakes always win at baseball? They have the best batter.",
+        "categories": []
+    },
+    {
+        "id": 1301,
+        "text": "Why did the baseball player get arrested? Because he stole second base.",
+        "categories": []
+    },
+    {
+        "id": 1302,
+        "text": "Why couldn't the couple get married at the library? It was all booked up.",
+        "categories": []
+    },
+    {
+        "id": 1303,
+        "text": "Why did the pug buy a clock? It wanted to be a watchdog.",
+        "categories": []
+    },
+    {
+        "id": 1304,
+        "text": "Where do hamburgers go to dance? The meatball.",
+        "categories": []
+    },
+    {
+        "id": 1305,
+        "text": "How did the dad prank his daughter using fake dog poop on April Fools Day? He told her to look out for her new sham-poo in the shower.",
+        "categories": []
+    },
+    {
+        "id": 1306,
+        "text": "What did the air conditioner say when it met a celebrity? I'm a big fan.",
+        "categories": []
+    },
+    {
+        "id": 1307,
+        "text": "What was Sherlock Holmes' favorite protein source? Mystery meat.",
+        "categories": []
+    },
+    {
+        "id": 1308,
+        "text": "What did the dryer say to the boring duvet cover that just got out of the washer? Don't be such a wet blanket.",
+        "categories": []
+    },
+    {
+        "id": 1309,
+        "text": "Why couldn't the bike stand up on its own? Because it was too tired.",
+        "categories": []
+    },
+    {
+        "id": 1310,
+        "text": "Why was the cow such a heartthrob on the farm? He was a s-moo-th talker.",
+        "categories": []
+    },
+    {
+        "id": 1311,
+        "text": "What's a writer's favorite train station? Penn Station.",
+        "categories": []
+    },
+    {
+        "id": 1312,
+        "text": "What do you call a gnat with a sore throat? A hoarse fly.",
+        "categories": []
+    },
+    {
+        "id": 1313,
+        "text": "What was said about the messy, angry man who was eating a can of Pringles? He's got a chip on his shoulder.",
+        "categories": []
+    },
+    {
+        "id": 1314,
+        "text": "What's it called when kittens get stuck in a tree? A cat-astrophe.",
+        "categories": []
+    },
+    {
+        "id": 1315,
+        "text": "What kind of shape may have been knighted? Sir-cles.",
+        "categories": []
+    },
+    {
+        "id": 1316,
+        "text": "Why is sand so optimistic? It has a can-dune attitude.",
+        "categories": []
+    },
+    {
+        "id": 1317,
+        "text": "What has four wheels and flies? A garbage truck.",
+        "categories": []
+    },
+    {
+        "id": 1318,
+        "text": "What part of the museum makes everyone sneeze? The sta-tues.",
+        "categories": []
+    },
+    {
+        "id": 1319,
+        "text": "What did the baker say when she won an award? It was a piece of cake.",
+        "categories": []
+    },
+    {
+        "id": 1320,
+        "text": "Why couldn't the couple respond right away when looking at wedding venues? They were engaged.",
+        "categories": []
+    },
+    {
+        "id": 1321,
+        "text": "What is Marco's favorite clothing store? Polo.",
+        "categories": []
+    },
+    {
+        "id": 1322,
+        "text": "What do you call it when a lawyer takes a test early in the morning? A breakfast bar.",
+        "categories": []
+    },
+    {
+        "id": 1323,
+        "text": "What do frogs use to track their exercise? Fit (rib)bits.",
+        "categories": []
+    },
+    {
+        "id": 1324,
+        "text": "How do frogs invest their money? They use a stock croaker.",
+        "categories": []
+    },
+    {
+        "id": 1325,
+        "text": "Why did police arrest the turkey? They suspected fowl play.",
+        "categories": []
+    },
+    {
+        "id": 1326,
+        "text": "What kind of cleaning product feels a lot of motivation in life? All-purpose.",
+        "categories": []
+    },
+    {
+        "id": 1327,
+        "text": "Where was the dripping coming from in the fridge? The leeks.",
+        "categories": []
+    },
+    {
+        "id": 1328,
+        "text": "Why was the hockey player gifted a new cap? He was known for his hat tricks.",
+        "categories": []
+    },
+    {
+        "id": 1329,
+        "text": "What vegetable is kind to everyone? The sweet potato.",
+        "categories": []
+    },
+    {
+        "id": 1330,
+        "text": "How was the handsome runner described? Dashing.",
+        "categories": []
+    },
+    {
+        "id": 1331,
+        "text": "What animals are the best to call if you get locked out of your house? Monkeys.",
+        "categories": []
+    },
+    {
+        "id": 1332,
+        "text": "What did the geometry teacher say when the class had trouble solving a problem? Let's try a different angle.",
+        "categories": []
+    },
+    {
+        "id": 1333,
+        "text": "Why don't phones ever go hungry? They have plenty of apps to choose from.",
+        "categories": []
+    },
+    {
+        "id": 1334,
+        "text": "Why couldn't the family leave the room after playing with Legos? They were blocked.",
+        "categories": []
+    },
+    {
+        "id": 1335,
+        "text": "What makes a basketball court trendy and accessorized? The hoops.",
+        "categories": []
+    },
+    {
+        "id": 1336,
+        "text": "What did the sapphire's best friend tell her? You're a real gem.",
+        "categories": []
+    },
+    {
+        "id": 1337,
+        "text": "Getting paid to sleep is a true dream job.",
+        "categories": []
+    },
+    {
+        "id": 1338,
+        "text": "Did you hear about the bossy man at the bar? He ordered everyone around.",
+        "categories": []
+    },
+    {
+        "id": 1339,
+        "text": "What do you give the dentist of the year? A little plaque.",
+        "categories": []
+    },
+    {
+        "id": 1340,
+        "text": "Why did the deer go to the dentist? It had buck teeth.",
+        "categories": []
+    },
+    {
+        "id": 1341,
+        "text": "Why did the Oreo go to the dentist? Because it lost its filling.",
+        "categories": []
+    },
+    {
+        "id": 1342,
+        "text": "What happens when doctors get frustrated? They lose their patients.",
+        "categories": []
+    },
+    {
+        "id": 1343,
+        "text": "Why was the traffic light late to work? It took too long to change.",
+        "categories": []
+    },
+    {
+        "id": 1344,
+        "text": "Did you hear about the guy who was afraid of hurdles? He got over it.",
+        "categories": []
+    },
+    {
+        "id": 1345,
+        "text": "Why didn't the sun go to college? It already had a million degrees.",
+        "categories": []
+    },
+    {
+        "id": 1346,
+        "text": "Did you hear about the guy who drank invisible ink? He's at the hospital waiting to be seen.",
+        "categories": []
+    },
+    {
+        "id": 1347,
+        "text": "What do you call a can opener that doesn't work? A can't opener.",
+        "categories": []
+    },
+    {
+        "id": 1348,
+        "text": "What do lawyers wear to work? Law suits.",
+        "categories": []
+    },
+    {
+        "id": 1349,
+        "text": "I used to be a banker, but I lost interest.",
+        "categories": []
+    },
+    {
+        "id": 1350,
+        "text": "Why did the computer catch cold? It left a window open.",
+        "categories": []
+    },
+    {
+        "id": 1351,
+        "text": "What do computers eat for a snack? Microchips.",
+        "categories": []
+    },
+    {
+        "id": 1352,
+        "text": "Why did the computer go to bed? It needed to crash.",
+        "categories": []
+    },
+    {
+        "id": 1353,
+        "text": "Why did the employee get fired from the keyboard factory? He wasn't putting in enough shifts.",
+        "categories": []
+    },
+    {
+        "id": 1354,
+        "text": "How do trees get on the internet? They log in.",
+        "categories": []
+    },
+    {
+        "id": 1355,
+        "text": "Why did the computer get glasses? To improve its website.",
+        "categories": []
+    },
+    {
+        "id": 1356,
+        "text": "What kind of bird works on a construction site? A crane.",
+        "categories": []
+    },
+    {
+        "id": 1357,
+        "text": "How much money does a skunk have? Only one scent.",
+        "categories": []
+    },
+    {
+        "id": 1358,
+        "text": "Why did the watch go on vacation? Because it needed to unwind.",
+        "categories": []
+    },
+    {
+        "id": 1359,
+        "text": "What does a painter do when he gets cold? Puts on another coat.",
+        "categories": []
+    },
+    {
+        "id": 1360,
+        "text": "How do you tell a scientist that they have bad breath? Offer them an experi-mint.",
+        "categories": []
+    },
+    {
+        "id": 1361,
+        "text": "How did the barber win the race? He knew a shortcut.",
+        "categories": []
+    },
+    {
+        "id": 1362,
+        "text": "Why did the roofer go to the doctor? He had shingles.",
+        "categories": []
+    },
+    {
+        "id": 1363,
+        "text": "Dogs can't operate MRI machines, but cats-can.",
+        "categories": []
+    },
+    {
+        "id": 1364,
+        "text": "What does a librarian use to go fishing? A bookworm.",
+        "categories": []
+    },
+    {
+        "id": 1365,
+        "text": "What did the roof say to the shingle? The first one is on the house.",
+        "categories": []
+    },
+    {
+        "id": 1366,
+        "text": "Why did the tailor get fired? He wasn't a good fit.",
+        "categories": []
+    },
+    {
+        "id": 1367,
+        "text": "What kind of bug can tell time? A clock-roach.",
+        "categories": []
+    },
+    {
+        "id": 1368,
+        "text": "Why did the girl toss a clock out the window? She wanted to see time fly.",
+        "categories": []
+    },
+    {
+        "id": 1369,
+        "text": "When does Friday come before Thursday? In the dictionary.",
+        "categories": []
+    },
+    {
+        "id": 1370,
+        "text": "How many telemarketers does it take to change a light bulb? Only one, but he has to do it while you are eating dinner.",
+        "categories": []
+    },
+    {
+        "id": 1371,
+        "text": "How many narcissists does it take to screw in a light bulb? One. The narcissist holds the light bulb while the rest of the world revolves around him.",
+        "categories": []
+    },
+    {
+        "id": 1372,
+        "text": "How many DIY buffs does it take to change a light bulb? One, but it takes two weeks and four trips to the hardware store.",
+        "categories": []
+    },
+    {
+        "id": 1373,
+        "text": "How many paranoids does it take to change a light bulb? Who wants to know?",
+        "categories": []
+    },
+    {
+        "id": 1374,
+        "text": "I read that by law you must turn on your headlights when it's raining in Sweden, but how am I supposed to know when it's raining in Sweden?",
+        "categories": []
+    },
+    {
+        "id": 1375,
+        "text": "I was addicted to the hokey pokey…but I turned myself around.",
+        "categories": []
+    },
+    {
+        "id": 1376,
+        "text": "I don't trust stairs. They are always up to something.",
+        "categories": []
+    },
+    {
+        "id": 1377,
+        "text": "Today, my son asked, Can I have a bookmark? I burst into tears—11 years old and he still doesn't know my name is Brian.",
+        "categories": []
+    },
+    {
+        "id": 1378,
+        "text": "When I was a kid, my dad got fired from his job as a road worker for theft. I refused to believe he could do such a thing, but when I got home, the signs were all there.",
+        "categories": []
+    },
+    {
+        "id": 1379,
+        "text": "Why didn't Han Solo enjoy his steak dinner? It was Chewie.",
+        "categories": []
+    },
+    {
+        "id": 1380,
+        "text": "Why don't pirates take a bath before they walk the plank? They just wash up on shore.",
+        "categories": []
+    },
+    {
+        "id": 1381,
+        "text": "Why do you never see elephants hiding in trees? Because they're so good at it.",
+        "categories": []
+    },
+    {
+        "id": 1382,
+        "text": "Did you hear about the racing snail who got rid of his shell? He thought it would make him faster, but it just made him sluggish.",
+        "categories": []
+    },
+    {
+        "id": 1383,
+        "text": "A turtle is crossing the road when he's mugged by two snails. When the police ask him what happened, the shaken turtle replies, I don't know. It all happened so fast.",
+        "categories": []
+    },
+    {
+        "id": 1384,
+        "text": "Did you hear about the guy who froze to death at the drive-in? He went to see Closed for the Winter.",
+        "categories": []
+    },
+    {
+        "id": 1385,
+        "text": "We all know about Murphy's Law: Anything that can go wrong will go wrong. But have you heard of Cole's Law? It's thinly sliced cabbage.",
+        "categories": []
+    },
+    {
+        "id": 1386,
+        "text": "When does a joke become a dad joke? When it becomes apparent.",
+        "categories": []
+    },
+    {
+        "id": 1387,
+        "text": "I had a happy childhood. My dad used to put me in tires and roll me down hills. Those were Goodyears.",
+        "categories": []
+    },
+    {
+        "id": 1388,
+        "text": "What invention allows us to see through walls? Windows.",
+        "categories": []
+    },
+    {
+        "id": 1389,
+        "text": "I know a bunch of good jokes about umbrellas, but they usually go over people's heads.",
+        "categories": []
+    },
+    {
+        "id": 1390,
+        "text": "The bank keeps calling me to give me compliments. They say I have an outstanding balance.",
+        "categories": []
+    },
+    {
+        "id": 1391,
+        "text": "What is the most popular fish in the ocean? A starfish.",
+        "categories": []
+    },
+    {
+        "id": 1392,
+        "text": "Barbers…you have to take your hat off to them.",
+        "categories": []
+    },
+    {
+        "id": 1393,
+        "text": "What did one plate say to another plate? Tonight, dinner's on me.",
+        "categories": []
+    },
+    {
+        "id": 1394,
+        "text": "Did you hear about the surgeon who enjoyed performing quick surgeries on insects? He did one on the fly.",
+        "categories": []
+    },
+    {
+        "id": 1395,
+        "text": "What's a vampire's favorite ship? A blood vessel.",
+        "categories": [
+            "Halloween"
+        ]
+    },
+    {
+        "id": 1396,
+        "text": "There's only one thing I can't deal with, and that's a deck of cards glued together.",
+        "categories": []
+    },
+    {
+        "id": 1397,
+        "text": "The past, the present, and the future walked into a bar. It was tense.",
+        "categories": []
+    },
+    {
+        "id": 1398,
+        "text": "Son: Dad, I'm hungry. Dad: Hi hungry, I'm Dad.",
+        "categories": []
+    },
+    {
+        "id": 1399,
+        "text": "Dad: Did you hear about the kidnapping at school? Son: No. What happened? Dad: The teacher woke him up.",
+        "categories": []
+    },
+    {
+        "id": 1400,
+        "text": "Daughter: I have a lot of friends named Nathan. There's Nathan Miller, Nathan Radcliff, Nathan Lewis… Me: When they are together, do you call them the United Nathans?",
+        "categories": []
+    },
+    {
+        "id": 1401,
+        "text": "What's the least-spoken language in the world? Sign language.",
+        "categories": []
+    },
+    {
+        "id": 1402,
+        "text": "What do you call a hippie's wife? Mississippi.",
+        "categories": []
+    },
+    {
+        "id": 1403,
+        "text": "I searched for a lighter on Amazon, but all I could find were 6,000 matches.",
+        "categories": []
+    },
+    {
+        "id": 1404,
+        "text": "I sold our vacuum cleaner; it was just gathering dust.",
+        "categories": []
+    },
+    {
+        "id": 1405,
+        "text": "What did the evil chicken lay? Deviled eggs.",
+        "categories": []
+    },
+    {
+        "id": 1406,
+        "text": "Did you hear they arrested the devil? Yeah, they got him on possession.",
+        "categories": []
+    },
+    {
+        "id": 1407,
+        "text": "A friend of mine didn't pay his exorcist. He got repossessed.",
+        "categories": []
+    },
+    {
+        "id": 1408,
+        "text": "How do you make holy water? You boil the hell out of it.",
+        "categories": []
+    },
+    {
+        "id": 1409,
+        "text": "What sound does a witch's car make? Broom broom!",
+        "categories": [
+            "Halloween"
+        ]
+    },
+    {
+        "id": 1410,
+        "text": "I want to go on record that I support farming. As a matter of fact, you could call me protractor.",
+        "categories": []
+    },
+    {
+        "id": 1411,
+        "text": "What's the best way to watch a fly-fishing tournament? Live stream.",
+        "categories": []
+    },
+    {
+        "id": 1412,
+        "text": "How do you tell the difference between an alligator and a crocodile? You will see one later and one in a while.",
+        "categories": []
+    },
+    {
+        "id": 1413,
+        "text": "Did you hear about the crustacean accused of promoting his own shellfish interests?",
+        "categories": []
+    },
+    {
+        "id": 1414,
+        "text": "Did you hear about the bankrupt poet who ode everyone?",
+        "categories": []
+    },
+    {
+        "id": 1415,
+        "text": "Did you hear about the shepherd who drove his sheep through town and was given a ticket for making a ewe turn?",
+        "categories": []
+    },
+    {
+        "id": 1416,
+        "text": "Did you hear about the cat who ate a ball of yarn? She had mittens.",
+        "categories": []
+    },
+    {
+        "id": 1417,
+        "text": "Did you hear about the claustrophobic astronaut? He just wanted a little more space.",
+        "categories": []
+    },
+    {
+        "id": 1418,
+        "text": "Why did the man name his dogs Rolex and Timex? Because they were watchdogs.",
+        "categories": []
+    },
+    {
+        "id": 1419,
+        "text": "What do you call a dog that can do magic? A Labracabrador.",
+        "categories": []
+    },
+    {
+        "id": 1420,
+        "text": "Why do dogs float in water? Because they are good buoys.",
+        "categories": []
+    },
+    {
+        "id": 1421,
+        "text": "What happens when it rains cats and dogs? You have to be careful not to step in a poodle.",
+        "categories": []
+    },
+    {
+        "id": 1422,
+        "text": "What do you call 50 pigs and 50 deer? 100 sows and bucks.",
+        "categories": []
+    },
+    {
+        "id": 1423,
+        "text": "Why do cows wear bells? Because their horns don't work.",
+        "categories": []
+    },
+    {
+        "id": 1424,
+        "text": "What do you call a fish with no eye? A fsh.",
+        "categories": []
+    },
+    {
+        "id": 1425,
+        "text": "Police arrested a bottle of water because it was wanted in three different states: solid, liquid, and gas.",
+        "categories": []
+    },
+    {
+        "id": 1426,
+        "text": "What do you call a lazy kangaroo? Pouch potato.",
+        "categories": []
+    },
+    {
+        "id": 1427,
+        "text": "Why is grass so dangerous? Because it's full of blades.",
+        "categories": []
+    },
+    {
+        "id": 1428,
+        "text": "What is the Easter bunny's favorite type of music? Hip-hop.",
+        "categories": []
+    },
+    {
+        "id": 1429,
+        "text": "A friend of mine is known for sweeping girls off their feet. He's an extremely aggressive janitor.",
+        "categories": []
+    },
+    {
+        "id": 1430,
+        "text": "I'm an expert at picking leaves and heating them in water. It's my special tea.",
+        "categories": []
+    },
+    {
+        "id": 1431,
+        "text": "My son's fourth birthday was today. When he came to see me, I didn't recognize him at first. I had never seen him be four.",
+        "categories": []
+    },
+    {
+        "id": 1432,
+        "text": "I recently went to the World's Tiniest Wind Turbine exhibit. Honestly, not a big fan.",
+        "categories": []
+    },
+    {
+        "id": 1433,
+        "text": "I was out on a walk when I saw a sign that said, Man wanted for robbery. So I went in and applied for the job.",
+        "categories": []
+    },
+    {
+        "id": 1434,
+        "text": "How long should socks be? Twelve inches, so you can fit in one foot.",
+        "categories": []
+    },
+    {
+        "id": 1435,
+        "text": "Did you hear the joke about experiencing déjà vu? Did you hear the joke about experiencing déjà vu?",
+        "categories": []
+    },
+    {
+        "id": 1436,
+        "text": "A bartender broke up with her boyfriend, but he kept asking her for another shot.",
+        "categories": []
+    },
+    {
+        "id": 1437,
+        "text": "I'm reading a novel where the main character has strained the muscles around his spine. That's his back story.",
+        "categories": []
+    },
+    {
+        "id": 1438,
+        "text": "My doctor told me I've really grown as a person. Well, her exact words were that I gained excess weight.",
+        "categories": []
+    },
+    {
+        "id": 1439,
+        "text": "What do you call someone who always states the obvious? Someone who always states the obvious.",
+        "categories": []
+    },
+    {
+        "id": 1440,
+        "text": "Scientists have discovered what is believed to be the world's largest bedsheet. More on this story as it unfolds.",
+        "categories": []
+    },
+    {
+        "id": 1441,
+        "text": "3.14 percent of sailors are pi-rates.",
+        "categories": []
+    },
+    {
+        "id": 1442,
+        "text": "You can't plant flowers if you haven't botany.",
+        "categories": []
+    },
+    {
+        "id": 1443,
+        "text": "What did the French chef give his wife for Valentine's Day? A hug and a quiche.",
+        "categories": []
+    },
+    {
+        "id": 1444,
+        "text": "A ham sandwich walks into a bar and orders a beer. The bartender says, Sorry, we don't serve food here.",
+        "categories": []
+    },
+    {
+        "id": 1445,
+        "text": "A couple of cups of yogurt walk into a country club. We don't serve your kind here, the bartender says. Why not? one yogurt asks. We're cultured.",
+        "categories": []
+    },
+    {
+        "id": 1446,
+        "text": "A brain walks into a bar and takes a seat. I'd like some wings and a pint of beer, please, it says. Sorry, but I can't serve you, the bartender replies. You're out of your head.",
+        "categories": []
+    },
+    {
+        "id": 1447,
+        "text": "A pirate walks into a bar with a paper towel on his head. The bartender says, What's with the paper towel? The pirate says, Arrr! I've got a Bounty on me head!",
+        "categories": []
+    },
+    {
+        "id": 1448,
+        "text": "A guy walks into a bar, and there's a horse serving drinks. The horse asks, What are you staring at? Haven't you ever seen a horse tending bar before? The guy says, It's not that. I just never thought the parrot would sell the place.",
+        "categories": []
+    },
+    {
+        "id": 1449,
+        "text": "Why did Beethoven get rid of his chickens? All they said was, Bach, Bach, Bach…",
+        "categories": []
+    },
+    {
+        "id": 1450,
+        "text": "What did one DNA say to the other DNA? Do these genes make me look fat?",
+        "categories": []
+    },
+    {
+        "id": 1451,
+        "text": "What do youneed to make a small fortune on Wall Street? A large fortune.",
+        "categories": []
+    },
+    {
+        "id": 1452,
+        "text": "How does the man in the moon get his hair cut? Eclipse it.",
+        "categories": []
+    },
+    {
+        "id": 1453,
+        "text": "Did you hear about the restaurant on the moon? Great food, no atmosphere.",
+        "categories": []
+    },
+    {
+        "id": 1454,
+        "text": "Did you hear the one about the kid who started a business tying shoelaces on the playground? It was a knot-for-profit.",
+        "categories": []
+    },
+    {
+        "id": 1455,
+        "text": "My kid wants to invent a pencil with an eraser on each end, but I just don't see the point.",
+        "categories": []
+    },
+    {
+        "id": 1456,
+        "text": "Teacher: There are two words I don't allow in my class. One is gross, and the other is cool. Johnny: So, what are the words?",
+        "categories": []
+    },
+    {
+        "id": 1457,
+        "text": "Why should you never mention the number 288? It's two gross",
+        "categories": []
+    },
+    {
+        "id": 1458,
+        "text": "I spent a lot of time, money, and effort childproofing my house, but the kids still get in.",
+        "categories": []
+    },
+    {
+        "id": 1459,
+        "text": "A cheese factory exploded in France. Da brie is everywhere!",
+        "categories": []
+    },
+    {
+        "id": 1460,
+        "text": "Did you hear the rumor about butter? Well, I'm not going to spread it!",
+        "categories": []
+    },
+    {
+        "id": 1461,
+        "text": "Why do melons have weddings? Because they cantaloupe.",
+        "categories": []
+    },
+    {
+        "id": 1462,
+        "text": "What do Bostonians call a fake noodle? An impasta.",
+        "categories": []
+    },
+    {
+        "id": 1463,
+        "text": "A college education now costs $100,000, but it produces three very proud people: the student, his mama, and his pauper.",
+        "categories": []
+    },
+    {
+        "id": 1464,
+        "text": "My son has his BA and his MA, but his P­A still supports him.",
+        "categories": []
+    },
+    {
+        "id": 1465,
+        "text": "What does a mobster buried in cement soon become? A hardened criminal.",
+        "categories": []
+    },
+    {
+        "id": 1466,
+        "text": "What does idk stand for? Everyone I ask says, I don't know.",
+        "categories": []
+    },
+    {
+        "id": 1467,
+        "text": "Why was the pig covered in ink? Because it lived in a pen.",
+        "categories": []
+    },
+    {
+        "id": 1468,
+        "text": "Did you hear about the guy who stole 50 cartons of hand sanitizer? They couldn't prosecute—his hands were clean.",
+        "categories": []
+    },
+    {
+        "id": 1469,
+        "text": "Why was the rookie police officer assigned to hunt the cannibal? The more seasoned officers had already been eaten.",
+        "categories": []
+    },
+    {
+        "id": 1470,
+        "text": "What do you call a snitching scientist? A lab rat.",
+        "categories": []
+    },
+    {
+        "id": 1471,
+        "text": "What's the difference between a man wearing pajamas on a bicycle and a guy wearing a tuxedo on a unicycle? Attire.",
+        "categories": []
+    },
+    {
+        "id": 1472,
+        "text": "It's a shame that the Beatles didn't make the submarine in that song green. That would've been sublime.",
+        "categories": []
+    },
+    {
+        "id": 1473,
+        "text": "Did you hear about the aquatic sea mammals that escaped from the zoo? It was otter chaos.",
+        "categories": []
+    },
+    {
+        "id": 1474,
+        "text": "What did the skeleton order with its beer? A mop.",
+        "categories": []
+    },
+    {
+        "id": 1475,
+        "text": "Why do nurses like red crayons? Sometimes they have to draw blood.",
+        "categories": []
+    },
+    {
+        "id": 1476,
+        "text": "How much do I love crunchy tacos? From my head tomatoes.",
+        "categories": [
+            "Cinco",
+            "De",
+            "Mayo"
+        ]
+    },
+    {
+        "id": 1477,
+        "text": "What kind of spells do leprechauns use? Lucky Charms.",
+        "categories": []
+    },
+    {
+        "id": 1478,
+        "text": "What do you call a bear with no teeth? A gummy bear.",
+        "categories": []
+    },
+    {
+        "id": 1479,
+        "text": "My IQ test results came back. They were negative.",
+        "categories": []
+    },
+    {
+        "id": 1480,
+        "text": "What do you get when you cross a polar bear with a seal? A polar bear.",
+        "categories": []
+    },
+    {
+        "id": 1481,
+        "text": "Did you hear about the nurse who was chewed out by the doctor because she was absent without gauze?",
+        "categories": []
+    },
+    {
+        "id": 1482,
+        "text": "If athletes get athlete's foot, what do astronauts get? Missile toe.",
+        "categories": []
+    },
+    {
+        "id": 1483,
+        "text": "My wife asked me to sync her phone, so I threw it into the ocean.",
+        "categories": []
+    },
+    {
+        "id": 1484,
+        "text": "My wife is really mad that I have no sense of direction. I packed up my stuff and right.",
+        "categories": []
+    },
+    {
+        "id": 1485,
+        "text": "What did one cannibal say to the other while they were eating a clown? Does this taste funny to you?",
+        "categories": []
+    },
+    {
+        "id": 1486,
+        "text": "Do I enjoy making courthouse puns? Guilty.",
+        "categories": []
+    },
+    {
+        "id": 1487,
+        "text": "What do you call someone with no body and no nose? Nobody knows.",
+        "categories": []
+    },
+    {
+        "id": 1488,
+        "text": "You know, people say they pick their nose, but I feel like I was just born with mine.",
+        "categories": []
+    },
+    {
+        "id": 1489,
+        "text": "In a freak accident today, a photographer was killed when a huge lump of cheddar landed on him. To be fair, the people who were being photographed did try to warn him.",
+        "categories": []
+    },
+    {
+        "id": 1490,
+        "text": "Can February March? No, but April May.",
+        "categories": []
+    },
+    {
+        "id": 1491,
+        "text": "Not sure if you have noticed, but I love bad puns. That's just how eye roll.",
+        "categories": []
+    },
+    {
+        "id": 1492,
+        "text": "If you see a robbery at an Apple store, does that make you an iWitness?",
+        "categories": []
+    },
+    {
+        "id": 1493,
+        "text": "What did the drummer call his twin daughters? Anna one, Anna two…",
+        "categories": []
+    },
+    {
+        "id": 1494,
+        "text": "What's a bad wizard's favorite computer program? Spell check.",
+        "categories": []
+    },
+    {
+        "id": 1495,
+        "text": "I was just reminiscing about the beautiful herb garden I had when I was growing up. Good thymes.",
+        "categories": []
+    },
+    {
+        "id": 1496,
+        "text": "I began to read a horror novel in braille. Something bad is about to happen—I can feel it.",
+        "categories": []
+    },
+    {
+        "id": 1497,
+        "text": "Why do pumpkins sit on porches? They have no hands to knock on the door.",
+        "categories": []
+    },
+    {
+        "id": 1498,
+        "text": "My friend wants to become an archaeologist, but I'm trying to put him off. I'm convinced his life will be in ruins.",
+        "categories": []
+    },
+    {
+        "id": 1499,
+        "text": "I got hit in the head with a can of Coke today. Don't worry, I'm not hurt. It was a soft drink.",
+        "categories": []
+    },
+    {
+        "id": 1500,
+        "text": "Cooking out this weekend? Don't forget the pickle. It's kind of a big dill.",
+        "categories": []
+    },
+    {
+        "id": 1501,
+        "text": "Justice is a dish best served cold. If it were served warm, it would be justwater.",
+        "categories": []
+    },
+    {
+        "id": 1502,
+        "text": "What's orange and sounds like a parrot? A carrot.",
+        "categories": []
+    },
+    {
+        "id": 1503,
+        "text": "A steak pun is a rare medium done well.",
+        "categories": []
+    },
+    {
+        "id": 1504,
+        "text": "Why did the raisin go out with the prune? Because he couldn't find a date.",
+        "categories": []
+    },
+    {
+        "id": 1505,
+        "text": "What's brown and sticky? A stick.",
+        "categories": []
+    },
+    {
+        "id": 1506,
+        "text": "My dog accidentally swallowed a bunch of Scrabble tiles. I think this could spell disaster.",
+        "categories": []
+    },
+    {
+        "id": 1507,
+        "text": "I wondered why the ball was getting bigger. Then it hit me.",
+        "categories": []
+    },
+    {
+        "id": 1508,
+        "text": "I had a date last night. It was perfect. Tomorrow, I'll try a grape.",
+        "categories": []
+    },
+    {
+        "id": 1509,
+        "text": "Armed robbers—some say they're a drain on society, but you've got to give it to them.",
+        "categories": []
+    },
+    {
+        "id": 1510,
+        "text": "It hurts me to say this, but I have a sore throat.",
+        "categories": []
+    },
+    {
+        "id": 1511,
+        "text": "I know a surgeon who puts organs back in upside down. I told him that's not funny, but he said it was an inside joke.",
+        "categories": []
+    },
+    {
+        "id": 1512,
+        "text": "My girlfriend says it's either her or my career as a news reporter. I have some breaking news for her.",
+        "categories": []
+    },
+    {
+        "id": 1513,
+        "text": "Inflation is really getting out of hand, but that's just my five cents.",
+        "categories": []
+    },
+    {
+        "id": 1514,
+        "text": "I can guess what people do for a living just by looking at their hands. I mean, I'm usually wrong, but I can guess.",
+        "categories": []
+    },
+    {
+        "id": 1515,
+        "text": "I've been breeding racing deer. Just trying to make a quick buck.",
+        "categories": []
+    },
+    {
+        "id": 1516,
+        "text": "How many mystery writers does it take to change a light bulb? Two: One to screw it in most of the way and another to give it a surprise twist at the end.",
+        "categories": []
+    },
+    {
+        "id": 1517,
+        "text": "My dentist offered me dentures for only a dollar. It sounded like a good deal at the time, but now I have buck teeth.",
+        "categories": []
+    }
+]

--- a/process_jokes_straight_apostrophes.py
+++ b/process_jokes_straight_apostrophes.py
@@ -1,0 +1,1598 @@
+# Python script to process the provided joke list and create jokes.json
+# with straight apostrophes.
+
+import json
+import re
+
+JOKE_DATA = """
+I’m afraid for the calendar. Its days are numbered.
+Why do fathers take an extra pair of socks when they go golfing?In case they get a hole in one!
+Singing in the shower is fun until you get soap in your mouth. Then it’s a soap opera.
+What do a tick and the Eiffel Tower have in common?They’re both Paris sites.
+What do you call a fish wearing a bowtie? Sofishticated.
+If April showers bring May flowers, what do May flowers bring? Pilgrims.
+What do you call a factory that makes okay products? A satisfactory.
+Have you heard about the chocolate record player? It sounds pretty sweet.
+I only know 25 letters of the alphabet. I don’t know y.
+What did one wall say to the other? I’ll meet you at the corner.
+Where do fruits go on vacation?Pear-is!
+What’s the best thing about Switzerland? I don’t know, but the flag is a big plus.
+What does a sprinter eat before a race? Nothing, they fast!
+What has more letters than the alphabet? The post office!
+What do you call a poor Santa Claus? St. Nickel-less. %%Christmas
+How do you get a squirrel to like you? Act like a nut.
+Why don’t eggs tell jokes? They’d crack each other up. %%Food
+I don’t trust stairs. They’re always up to something.
+What do you call someone with no body and no nose? Nobody knows.
+Did you hear the rumor about butter? Well, I’m not going to spread it! %Food
+Why couldn’t the bicycle stand up by itself? It was two tired.
+What did one hat say to the other? Stay here! I’m going on ahead.
+This graveyard looks overcrowded. People must be dying to get in.
+What does a lemon say when it answers the phone? Yellow! %%Food
+Why can’t a nose be 12 inches long? Because then it would be a foot.
+What kind of car does an egg drive? A yolkswagen. %%Food
+How do you make 7 even? Take away the s.
+How many tickles does it take to make an octopus laugh? Ten tickles.
+Why don’t eggs tell jokes? They’d crack each other up. %Food
+What do you call an angry carrot? A steamed veggie. %%Food
+It takes guts to be an organ donor.
+How do you make a tissue dance? You put a little boogie in it.
+Why did the math book look so sad? Because of all of its problems! %%School
+What do you call cheese that isn’t yours? Nacho cheese. %%Food
+How does a penguin build its house? Igloos it together.
+What country’s capital is growing the fastest? Ireland. Every day it’s Dublin.
+I’m on a seafood diet. I see food and I eat it. %%Food
+Why did the scarecrow win an award? Because he was outstanding in his field.
+I made a pencil with two erasers. It was pointless.
+I’m reading a book about anti-gravity. It’s impossible to put down!
+Did you hear about the guy who invented the knock-knock joke? He won the ’no-bell’ prize.
+I’ve got a great joke about construction, but I’m still working on it.
+I used to hate facial hair...but then it grew on me.
+I decided to sell my vacuum cleaner—it was just gathering dust!
+You know, people say they pick their nose, but I feel like I was just born with mine.
+What’s brown and sticky? A stick.
+What do you call an elephant that doesn’t matter? An irrelephant. %%Animal
+What do you get from a pampered cow? Spoiled milk.
+If you see a crime at an Apple Store, does that make you an iWitness?
+I was going to tell a time-traveling joke, but you guys didn’t like it.
+What do you call a fake noodle? An impasta. %%Food
+What do you call a belt made of watches? A waist of time.
+What do you call a pony with a sore throat? A little hoarse. %%Animal
+Mountains aren’t just funny. They’re hill areas.
+How much does it cost Santa to park his sleigh? Nothing, it’s on the house. %%Christmas
+What’s a robot’s favorite snack? Computer chips. %%Food
+Why are piggy banks so wise? They’re filled with common cents.
+How do you get a good price on a sled? You have toboggan. %%Winter
+Where do young trees go to learn? Elementree school %%School
+Wanna hear a joke about paper? Never mind—it’s tearable.
+I could tell a joke about pizza, but it’s a little cheesy. %%Food
+Don’t trust atoms. They make up everything!
+When does a joke become a dad joke? When it becomes apparent.
+I don’t play soccer because I enjoy the sport. I’m just doing it for kicks! %%Sports
+Which state has the most streets? Rhode Island.
+Did you hear about the fire at the shoe factory? Unfortunately, many soles were lost.
+What do you call a pig who knows how to use a knife? A pork chop. %%Food
+Why did the pony ask for a glass of water? Because it was a little horse. %%Animal
+How many apples can you grow on a tree? All of them. %%Food
+What do kids play when they have nothing else to do? Bored games.
+What kind of music do elves listen to? Wrap music. %%Christmas
+What does cake and baseball have in common? They both need a batter. %%Sports
+When does Friday come before Thursday? In the dictionary.
+How can you tell if a pig is hot? It’s bacon. %%Food
+What do you call a rude cow? Beef jerky %%Animal
+How do you get a squirrel’s attention? Act like a nut. %%Animal
+Did you hear about the cat that ate a lemon? Now it’s a sour puss. %%Animal
+What did one volcano say to the other? I lava you.
+How do mice floss their teeth? With string cheese. %%Animal
+How do you cook an alligator? With a croc-pot. %%Animal
+What did the earthquake say when it was done? Sorry, my fault!
+Why did the computer go to bed? It needed to crash.
+What kind of bug can tell time? A clock-roach. %%Animal
+What do you call a can opener that doesn’t work? A can’t opener.
+What do pigs use to clean up? Hogwash. %%Animal
+What’s a pirate’s favorite letter? You’d think it’s the R, but it’s really the C. %%Pirate
+When is a door not a door? When it’s ajar.
+Did you hear about the broken guitar for sale? It comes with no strings attached.
+Once I read a book about glue. I couldn’t put it down.
+What do you call a fish with no eyes? Fsh. %%Animal
+What should you do if you meet a giant? Use big words.
+What do you call a cow with two legs? Lean beef. %%Animal
+What sits on the seabed and has anxiety? A nervous wreck.
+What’s the best air to breathe if you want to be rich? Millionaire.
+Why did the girl toss a clock out the window? She wanted to see time fly.
+Where do armies belong? In your sleeves.
+Where did the king put his armies? In his sleevies!
+What did one plate say to another plate? Tonight, dinner’s on me.
+What happens when doctors get frustrated? They lose their patients.
+What do you call a bear with no teeth? A gummy bear. %%Animal
+What invention allows us to see through walls? Windows.
+What’s orange and sounds like a parrot? A carrot. %%Animal
+Why did the coach go to the bank? To get his quarter back. %%Sports
+Why do nurses like red crayons? Sometimes they have to draw blood.
+What kind of jewelry do rabbits wear? 14 carrot gold. %%Animal
+Why can’t the pirate learn the alphabet? Because he kept getting lost at C. %%Pirate
+What do you call a cheese that isn’t yours? Nacho cheese! %%Food
+How do celebrities keep cool? They have many fans.
+What did the janitor say when he jumped out of the closet? Supplies!
+What’s more unbelievable than a talking dog? A spelling bee. %%Animal
+What do you call a cow with no legs? Ground beef. %%Animal
+What do you call a happy cowboy? A jolly rancher.
+Why shouldn’t you trust trees? They seem shady.
+How do you fix a broken tomato? With tomato paste. %%Animal
+What kind of music scares balloons? Pop music.
+Why did the orange stop halfway across the road? It ran out of juice. %%Animal %%Cross the road
+Why did the Oreo go to the dentist? It lost its filling. %%Animal
+How do you get an astronaut’s baby to stop crying? You rocket.
+What do dogs and phones have in common? Both have collar ID. %%Animal
+Why shouldn’t you play poker in the jungle? Too many cheetahs. %%Animal
+What sounds like a sneeze and is made of leather? A shoe.
+How do you stop a bull from charging? You cancel its credit card. %%Animal
+Why was the math book sad? It had too many problems. %%School
+Why are fish so smart? Because they swim in schools. %%School
+Why did the employee get fired from the keyboard factory? He wasn’t putting in enough shifts.
+Did you hear about the man who cut off his left leg? He’s all right now.
+Did you hear the one about the claustrophobic astronaut? He just needed a little space.
+What kind of music should you listen to while fishing? Something catchy!
+What do you call a girl in the middle of a tennis court? Annette. %%Sports
+What did the ocean say to the beach? Nothing. It just waved. %%Beach
+What did one wall say to the other? I’ll meet you at the corner.
+Why did the nose feel sad? It was always getting picked on.
+Did you hear about the cold dinner? It was chili. %%Food
+Why did the deer go to the dentist? It had buck teeth. %%Animal
+Why can’t you trust a balloon? It’s full of hot air.
+A cheese factory exploded in France. Da brie is everywhere! %%Animal
+Not sure if you have noticed, but I love bad puns. That’s just how eye roll.
+Why did the banana go to the doctor? Because it wasn’t peeling well. %%Food
+Where does a sheep go to get a haircut? The baa baa shop. %%Animal
+What did the mama cow say to the baby cow? It’s pasture bed time. %%Animal
+Why should you never use a dull pencil? Because it’s pointless.
+Why did the cookie go to the doctor? It was feeling crumby. %%Food
+Where did the cat go after losing its tail? The retail store. %%Animal
+Why don’t eggs tell jokes? They’d crack each other up. %%Food
+What kind of sandals do frogs wear? Open-toad. %%Animal
+What do you call a herd of sheep falling down a hill? A lambslide. %%Animal
+How do you organize a space party? You planet.
+How many tickles does it take to make an octopus laugh? Ten tickles. %%Animal
+What do you call a potato wearing glasses? A spec-tater. %%Food
+What do you call a moose with no name? Anonymoose. %%Food
+Why did the ram run over the cliff? He didn’t see the ewe turn. %%Animal
+Why did the picture go to jail? He was framed.
+What is a calendar’s favorite food? Dates.
+Why was the football stadium cold? There were too many fans. %Sports
+Why do bananas wear sunscreen? Because they peel. %%Food
+Why do bees have sticky hair? Because they use honey combs. %Animal
+Why did the watch go on vacation? To unwind.
+How does a penguin build a house? Igloos it together. %%Animal
+Why do melons have weddings? Because they cantaloupe.
+Why did the computer get glasses? To improve its website.
+What did the blanket say to the bed? I’ve got you covered.
+What did the roof say to the shingle? The first one’s on the house.
+What do you call birds that stick together? Velcrows %%Animal
+Why did the duck fall on the sidewalk? He tripped on a quack. %%Animal
+How do birds learn to fly? They wing it. %%Animal
+Did you hear about the walnut and cashew that threw a party? It was nuts. %%Food
+Did the hear about the ice cream truck accident? It crashed on a rocky road.
+What kind of bird works on a construction site? A crane. %%Animal
+What did one elevator say to the other elevator? I think I’m coming down with something.
+What did the hamburger name its baby? Patty.
+What type of music do the planets enjoy? Neptunes.
+Why did the phone wear glasses? Because it lost all its contacts.
+Why do bakers work so hard? Because they knead dough.
+Why are fish so easy to weigh? Because they have their own set of scales.
+What do you call a priest that becomes a lawyer? A father-in-law.
+What do you give a scientist with bad breath? Experi-mints.
+What did Benjamin Franklin say when he discovered electricity? Nothing. He was too shocked.
+What do you call a medieval lamp? A knight light.
+What did one hat say to the other? You go on ahead.
+Why did the frog take the bus to work? His car got toad.
+What does an evil hen lay? Deviled eggs.
+How can you tell the difference between a dog and tree? By their bark.
+Why do dragons sleep during the day? Because they like to fight knights.
+Why did the scarecrow win an award? It was outstanding in his field.
+Did you hear about the 12-inch dog? It was a foot long.
+Why did the baseball player get arrested? He stole third base.
+What did one piece of tape say to the other? Let’s stick together.
+What’s brown and sticky? A stick.
+How does the rancher keep track of his cattle? With a cow-culator.
+What do you call a shoe made out of a banana? A slipper.
+How you fix a broken pumpkin? With a pumpkin patch.
+Where do boats go when they’re sick? To the dock.
+Can February March? No, but April May!
+What do you call a fibbing cat? A lion.
+Did you hear the rumor about butter? Well, I’m not going to go spreading it!
+Where do you learn to make ice cream? Sundae school.
+What’s a scarecrow’s favorite fruit? Straw-berries
+Where do burgers go dancing? At the meatball.
+What time do ducks wake up? At the quack of dawn.
+Why was the broom late? It over-swept.
+What kind of tree fits in your hand? A palm tree.
+Where do books hide when they’re afraid? Under their covers.
+How do trees get on the internet? They log in.
+What does a painter do when he gets cold? Puts on another coat.
+What did the calculator say to the pencil? You can count on me.
+What has four wheels and flies? A garbage truck.
+What do you call two ducks and a cow? Quackers and milk.
+What do cows like to read? Cattle-logs.
+How did the farmer fix his torn overalls? With a cabbage patch.
+How much money does a skunk have? Just one scent.
+What do you get when you cross an elephant and a fish? Swimming trunks.
+What kind of cereal do leprechauns eat? Lucky Charms.
+What do you call recently-married spiders? Newly-webs.
+Where do crayons go on vacation? Color-ado.
+What do you get when you cross a Smurf and a cow? Blue cheese.
+What happens when ice cream gets angry? It has a meltdown.
+What do you call a locomotive carrying bubble gum? A chew chew train.
+How do you get a mouse to smile? Say cheese.
+Why couldn’t the bike stand up on its own? It was too tired.
+What do you call a sheep that knows karate? A lamb chop.
+Why did the snowman buy a bag of carrots? He wanted to pick his nose.
+What did the Dalmatian say after dinner? That hit the spot.
+How do you know when a bike is thinking? You can see its wheels turning.
+What does a librarian use to go fishing? A bookworm.
+What did one leaf say to the other? I’m falling for you.
+Where’s the one place you should never take your dog? A flea market.
+How does Darth Vader like his bagels? On the dark side.
+What do you call spaghetti in disguise? An impasta.
+Why did the tailor get fired? He wasn’t a good fit.
+Where do elephants store luggage? In a trunk.
+Did you hear about the red and blue ships that collided? All the sailors were marooned.
+My neighbor gave me a new roof for free. He said it was on the house.
+Did you hear about the teenager who failed his driving test? He thought it was a crash course.
+Where do surfers learn to surf? At boarding school.
+A duck walks into a bar and buys everyone a round. He tells the bartender, Put it on my bill.
+What has a spine but no bones? A book.
+What do you call a wizard who’s good with ceramics? Harry Pottery.
+Why did Marie Curie stop dating that guy? There was no chemistry.
+Did you hear about the nurse who didn’t want to become a doctor? She didn’t have the patients.
+Why did the tourist feel disappointed upon seeing the Liberty Bell? It wasn’t all it was cracked up to be.
+How did Vikings communicate with one another? By Norse code.
+How did Benjamin Franklin feel when he discovered electricity? He was shocked!
+Which is the worst sport to play? Bad-minton.
+Why don’t the other farm animals like playing basketball with pigs? They’re ball hogs.
+How do ghosts stay in shape? They exorcise.
+What do rabbits need after getting caught in the rain? A hare dryer.
+Why did the coach put the frog in the outfield? He’s really good at catching flies.
+What board game is popular in Prague? Czechers.
+What kind of shoes does a lazy person wear? Loafers.
+Why didn’t the invisible man go to the dance? He didn’t have any body to take.
+Dad, did you get a haircut? No, I got them all cut!
+What did one candle say to the other? Do you want to go out tonight?
+Why did the bed wear a disguise? It was undercover.
+What do you call a boomerang that doesn’t come back? A stick.
+What do you call a monster with a high IQ? Frank-Einstein.
+Why was the Incredible Hulk so good at gardening? He had a green thumb.
+What kind of music does a boulder like? Rock ‘n’ roll.
+Why did the elephant quit his job? He was working for peanuts.
+What did the shovel say to the sand? I really dig you!
+What are the least expensive type of teeth? Buck teeth.
+What would happen if you threw all the books in the ocean? It would cause a title wave.
+Why did the queen go to the dentist? To get crowns on her teeth.
+What’s the best kind of music to listen to when fishing? Something catchy.
+How did the pirate get his ship for so cheap? It was on sail.
+Today my son asked me, Can I have a bookmark? I burst into tears — he’s 12 years old and still doesn’t know my name!
+Why do dads take an extra pair of socks when they play golf? In case they get a hole in one.
+What do you call a fish with no eyes? A fsh.
+Why don’t seagulls fly over the bay? Because then they’d be bagels (bay gulls).
+What comes once in a minute, twice in a moment but never in a thousand years? The letter M.
+What’s the best kind of bird to work for at a construction company? A crane.
+What did the T-Rex use to cut wood? A dino-saw.
+I got fired from my job as a taxi driver. It turns out nobody thought I was fare.
+What do you call a snake that loves building houses? A boa constructor.
+Where do fish keep their money? In a river bank.
+Why did the man put his money in the freezer? He wanted cold, hard cash.
+When does it rain money? When there is a change in the weather.
+Why don’t scientists trust atoms? Because they make up everything.
+What do a tick and the Eiffel Tower have in common? They’re both Paris sites.
+Why did the man get fired from the banana factory? He kept throwing away the bent ones.
+Whoever stole my depression medication — I hope you’re happy now.
+Why can’t a leopard hide? Because he’s always spotted.
+What do you call two monkeys who share an Amazon account? Prime mates.
+What do you call a penguin in the White House? Lost.
+What do you call a kangaroo’s lazy joey? A pouch potato.
+What did the llama say to his date? Want to go on a picnic? Alpaca lunch.
+Did you hear that I’m reading a book about anti-gravity? It’s impossible to put down.
+Which is faster, hot or cold? Hot, because you can catch a cold.
+Which bear is the most condescending? A pan-duh.
+What kind of noise does a witch’s vehicle make? Brrrroooom, brrroooom.
+Singing in the shower is fun until you get soap in your mouth. Then it’s a soap opera.
+I only know 25 letters of the alphabet. I don’t know y.
+How does the moon cut his hair? Eclipse it.
+What do you call a factory that makes OK products? A satisfactory.
+What did the janitor say when he jumped out the closet? Supplies!
+What did the buffalo say to his son when he dropped him off at school? Bison!
+I can tolerate algebra, maybe even a little calculus, but geometry is where I draw the line.
+Why do bees have sticky hair? Because they use a honeycomb.
+What kind of music do chiropractors like? Hip pop.
+What has five toes and isn’t your foot? My foot.
+What did the cannibal choose as his last meal? Five Guys.
+Me: Go to bed, the cows are already asleep in the field. Son: So what? Me: It’s pasture bedtime.
+What do you call a Frenchman in sandals? Philippe Philoppe.
+I bought the world’s worst thesaurus yesterday. Not only is it terrible, it’s terrible.
+Why did the scarecrow get an award? Because he was outstanding in his field.
+What do you get if you cross an angry sheep with a moody cow? An animal that’s in a baaaaad mooood.
+Can a kangaroo jump higher than the Empire State Building? Of course! Buildings can’t jump.
+What did the sink tell the toilet? You look flushed.
+What happens when a snowman throws a tantrum? He has a meltdown.
+My extra winter weight is finally gone. Now, I have spring rolls.
+I just found out I’m colorblind. The news came out of the orange!
+Did you hear that laughing too loudly is illegal in Hawaii? They only permit a-low-ha.
+I hate my job — all I do is crush cans all day. It’s soda pressing.
+Mom keeps asking why I have so much candy. She doesn’t know I always keep a few Twix up my sleeve.
+I found a wooden shoe in my toilet — it was clogged.
+If a pig loses its voice, does it become disgruntled?
+I love dad jokes, but I don’t have kids, which makes me a Faux Pa.
+I only know 25 letters of the alphabet — I just don’t know y.
+My dream job is to clean mirrors, because I can really see myself doing that.
+I lost 25% of my roof last night...oof.
+I don’t trust stairs. They’re always up to something.
+RIP, boiling water. You will be mist.
+Two guys walked into a bar. The third guy ducked.
+Two peanuts went walking down the street. One was assaulted.
+I’m so good at sleeping that I can do it with my eyes closed!
+I had a dream that I weighed less than a thousandth of a gram. I was like, 0mg.
+Mom said I should do lunges to stay in shape. That would be a big step forward.
+Time flies like an arrow. Fruit flies like a banana.
+Every time I take my dog to the park, the ducks try to bite him. That’s what I get for buying a pure bread dog.
+6:30 is my favorite time of day, hands down.
+Whenever you get a bad sausage, it’s just the wurst.
+My dog is a genius. I asked him, What’s two minus two? He said nothing.
+I used to run a dating service for chickens, but I was struggling to make hens meet.
+Mom texted me to say our Italian restaurant is out of pasta, and now we’re penneless.
+Justice is a dish best served cold. If it were served warm, it would be justwater.
+I used to hate facial hair, but then it grew on me.
+Most people can’t tell the difference between entomology and etymology. I can’t find the words for how much this bugs me.
+A magician was walking down the street — then he turned into a store.
+We’re renovating the house, and the first floor is going great, but the second floor is another story.
+I’m reading an anti-gravity book, and I just can’t put it down!
+At first, I thought my chiropractor wasn’t any good, but now I stand corrected.
+My toddler is refusing to nap. He’s guilty of resisting a rest.
+I used to be able to play piano by ear, but now I have to use my hands.
+I failed my calculus exam because I was sitting in the middle of identical twins — I couldn’t differentiate between them.
+My boss asked me why I only get sick on work days. I said it must be my weekend immune system.
+Every night, I have hard time remembering something, but then it dawns on me.
+The wedding was so beautiful, even the cake was in tiers.
+I can tolerate algebra, maybe even a little calculus but geometry is where I draw the line.
+I was wondering why the baseball kept getting bigger and bigger. Then it hit me.
+Have you heard about the new corduroy pillows — they’re making headlines!
+My therapist told me I have problems expressing my emotions. Can’t say I’m surprised.
+I was once a personal trainer, until I gave a too-weak notice.
+I just paid $100 for a belt that doesn’t fit — what a huge waist!
+I finally watched that documentary on clocks. It was about time.
+Bigfoot is sometimes confused for Sasquatch — Yeti never complains.
+Your mom and I let astrology get between us. It just Taurus apart.
+A guy walked into a bar, and lost the limbo contest.
+I wanted to eat a watch for lunch, but it was too time-consuming.
+I ordered a chicken and an egg online. I’ll let you know what comes first.
+It’s raining cats and dogs, so be careful not to step in a poodle.
+I decided to sell the vacuum cleaner — it was just gathering dust!
+My boss told me to have a good day, so I went home!
+Mom says I have no sense of direction, so I packed my bags and right.
+If money doesn’t grow on trees, then why do banks have branches?
+Mom is mad at me because she asked me to sync her phone, so I threw it in the ocean.
+I’d avoid the sushi if I were you — it’s a little fishy!
+I can tell when you’re lying just by looking at you. I can also tell when you’re standing.
+I was going to go on an expensive vacation with a classical pianist, but he was too baroque.
+Mom asked me to put ketchup on the grocery list, and now I can’t read what else is on it.
+Can anyone tell me what oblivious means, because I have no idea.
+My friend couldn’t pay his water bill, so I sent him a get well soon card
+Does anybody know where a dad can find a person to talk to and hang out with? Asking for a friend.
+Lance isn’t that common a name these days, but in medieval times, they were called lance-a-lot.
+After dinner Mom asked if I could clear the table. I needed a running start, but I made it.
+I want to name my puppies Rolex and Timex so I can have watch dogs.
+I love telling Dad jokes. Sometimes, he even laughs.
+What does a baby computer call its father? Data!
+What’s green and has wheels? Grass! I lied about the wheels.
+Where do pirates get their hooks? Second hand stores!
+Why are pupils are the last part of your body to stop working when you die? They dilate!
+What do you call a line of dads waiting to get haircuts? The barberqueue!
+What do you call a beehive with no exit? Unbelievable!
+What did the doctor say to the panicked man who was afraid he was shrinking? Settle down — you’ll have to learn to be a little patient!
+Why was 2019 afraid of 2020? Because they had a fight and 2021!
+Why should you never brush your teeth with your left hand Because a toothbrush works better!
+What do you call a rude cow? Beef jerky!
+What’s the best thing about living in Switzerland? I don’t know, but the flag is a big plus!
+Why are balloons so expensive? Inflation!
+What is the most popular time for a dentist appointment? Tooth hurty!
+Do you want to hear two short jokes and a long joke? Joke! Joke! Jooooooooooooooooke.
+What do you call cheese that isn’t yours? Nacho cheese!
+Why can’t you send a duck to space? Because the bill would be astronomical!
+What side of a tree grows the most branches? The outside!
+What happened when the world’s tongue-twister champion got arrested? They gave him a tough sentence.
+Why did an old man fall in a well? Because he couldn’t see that well!
+Did you hear about that person who was afraid of jumping a hurdle? They got over it!
+What do you call a fish with no eye? A fsh.
+What breed of dog can jump higher than a skyscraper? Any breed of dog! Skyscrapers can’t jump.
+Why are elevator jokes so good? They work on many levels!
+Why are peppers the best at archery? Because they habanero!
+What state is known for its tiny beverages? Minnesota!
+Why did the computer get mad at the printer? Because it didn’t like its toner voice.
+What did the three-legged dog say when he walked into a saloon? I’m looking for the man who shot my paw.
+What’s the best way to watch a fly-fishing tournament? Live stream it!
+Why did the broom decide to go to bed? It was very sweepy!
+Why are nurses always running out of red crayons? Because they often have to draw blood!
+Did you hear about the square that got into a car accident? Yeah, now he’s a rect-angle!
+What do you call an illegally parked frog? Toad!
+How do you tell the difference between a bull and a cow? It is either one or the utter.
+What’s red and smells like blue paint? Red paint!
+Why can’t you ever run through a campsite? You can only ran — it’s always past tents!
+Why was the woman afraid for the calendar? She said its days were numbered!
+Why is it hard to understand volunteers? Because they make no cents!
+What did the police officer say to his belly-button? You’re under a vest!
+What’s the easiest way to burn 1,000 calories? Leave the pizza in the oven!
+What do you call a hippie’s wife? Mississippi!
+What’s the difference between a badly dressed kid on a bicycle and a well dressed kid on a tricycle? Attire!
+What did the drummer call his twin daughters? Anna One, Anna Two!
+Did you hear about the king who was exactly 12 inches tall? He was a great ruler!
+What’s the difference between a hippo and a Zippo? One is very heavy, the other is a little lighter.
+How do you cure a fear of a speed bump? You slowly get over it.
+Why is the cow always smiling? It’s in a good mooood I guess!
+When did they find water on the moon? When it was waning!
+What do you call a boomerang that doesn’t come back? A stick!
+Why is Peter Pan always flying? Because he Neverlands!
+Why don’t astronomers like Orion’s Belt? It’s a big waist of space!
+What did the photon say to the hotel bellhop? No luggage, I’m traveling light!
+Why did the coffee go to the police? To report a mugging!
+What’s the difference between a dad joke and a bad joke? The direction of the first letter.
+I have a joke about putting in a light bulb, but I’m afraid I’ll screw it up.
+I have a joke about chemistry, but I don’t think it’ll get a reaction.
+I have a joke about banking, but I lost interest.
+I have a joke about cows, but I don’t want to milk it.
+I have a joke about kites, but it would just sail over your head.
+I have a joke about scary math, but I’m 2² to say it.
+I have a joke about construction, but I’m still working on it.
+I have a joke about time travel, but you guys didn’t get it.
+I have a joke about being an electrician, but it’s too shocking.
+I have a joke about hunting for fossils, but you probably wouldn’t dig it.
+I have a joke about a broken pencil, but it’s pointless.
+I have a joke about the flu, but I hope you don’t get it.
+I have a joke about statistics, but it’s not significant.
+I have a joke about pizza, but it’s too cheesy.
+I have a joke about immortality, and it never gets old.
+I have a joke about paper, but it’s tearable.
+I have a joke about trickle-down economics, but 99% of you will never get it.
+I have a joke about drilling, but it’s boring.
+I have a joke about being a rejected organ donor, but I just don’t have the guts to tell it.
+I had a joke about canned juice, but I couldn’t concentrate.
+I have a few jokes about retired people, but none of them work.
+I have a joke about a broken clock, but it’s not the right time.
+I have a joke about nepotism, but I’ll only give it to my kids.
+I have a joke about butter, but I’m not going to spread it.
+I have a joke about a roof, but it would just go over your head.
+I have a joke about inferiority complexes, but it’s not very good.
+I have a joke about procrastination, but I’ll tell it to you later.
+Why does Marvel advertise The Hulk the most? Because he’s basically one big Banner!
+What’s E.T. short for? Because he’s only got tiny legs!
+What concert costs just 45 cents? 50 Cent featuring Nickelback!
+What’s Forrest Gump’s email password? 1Forrest1
+What does Jeff Bezos do before he goes to sleep? He puts his PJ-Amazon.
+How do you follow Will Smith in the snow? You follow the fresh prints.
+How does Darth Vader like his toast? On the dark side.
+Why won’t Apple start making cars? They wouldn’t support windows.
+What type of coordination was Whitney Houston most famous for? Hand eeeeyeeeeee!
+What do you say when Dwayne Johnson buys something to cut with? Rock pay-for scissors.
+To the person stole my laptop with my copy of Microsoft Office on it: I will find you. You have my Word!
+To the person who stole my glasses: I will find you. I have contacts.
+To the person who stole my place in line: I’m after you now.
+To the person who stole my limbo stick: That was a new low.
+To the person who stole my dictionary: I have no words.
+To the person who stole my bed: I won’t rest until I find you.
+To the person who stole my depression medication: I hope you’re happy now.
+To the person who stole my case of energy drinks: I hope you can’t sleep at night.
+To the person who stole my power steering: I just can’t handle it.
+To the person who stole my diary and then died: My thoughts are with your family.
+RIP boiling water, you will be mist.
+I once wrote a song about a tortilla, but it’s more of a wrap.
+A witch’s vehicle goes brrroom brrroom!
+The waiter asked if I wanted a box for my leftovers, but I told him I’m not into fighting.
+If you see a crime at an Apple store, are you an iWitness?
+If the early bird catches the worm, I’ll sleep in until there are pancakes.
+The wedding was so beautiful, even the cake was in tiers.
+I used to be able to play the piano by ear, but now I have to use my hands.
+Did Noah include termites on the ark?
+I used to hate facial hair, but it grew on me.
+Keep the dream alive, and hit the snooze button.
+I tell dad jokes but I have no kids. I’m a faux pa.
+I’m afraid of speed bumps, but I am slowly getting over it.
+Some people think prison is one word, but to robbers, it’s the whole sentence.
+I used to be addicted to soap, but I’m clean now.
+Spring is here! I got so excited I wet my plants!
+I poured root beer in a square glass. Now I just have beer.
+I had a dream about being a muffler. I woke up exhausted.
+Talk is cheap until you talk to a lawyer.
+A pony with a cough is just a little horse.
+It takes guts to be an organ donor.
+To whoever stole my copy of Microsoft Office, I will find you. You have my Word!
+How do celebrities stay cool? They have many fans.
+What’s Forrest Gump’s Facebook password? 1forest1.
+What did the fisherman say to the magician? Pick a cod, any cod.
+What do you call a fake noodle? An impasta.
+How do you organize a space party? You planet.
+Did you know that milk is the fastest liquid on earth? It’s pasteurized before you can even see it.
+What does a baby computer call his father? Data.
+Why can’t a leopard hide? Because he’s always spotted.
+How many tickles does it take to make an octopus laugh? 10 tickles.
+What do you call an illegally parked frog? Toad.
+Why are spiders so smart? They can find everything on the web.
+It’s inappropriate to make a dad joke if you’re not a dad. It’s a faux pa.
+Did you hear about the circus fire? It was in tents.
+Can February March? No, but April May!
+How do lawyers say goodbye? We’ll be suing ya!
+Wanna hear a joke about paper? Never mind—it’s tearable.
+What’s the best way to watch a fly fishing tournament? Live stream.
+I could tell a joke about pizza, but it’s a little cheesy.
+Every time I take my dog to the park, the ducks try to bite him. That’s what I get for buying a pure bread dog.
+What is a funny mountain called? Hill-arious.
+I wouldn’t buy anything with velcro. It’s a total rip-off.
+What time did the man go to the dentist? Tooth hurt-y.
+What kind of egg did the evil chicken lay? A deviled egg.
+Which is faster, hot or cold? Hot, because you can catch a cold.
+I made a pencil with two erasers. It was pointless.
+How does a bee brush its hair? It uses a honeycomb.
+How do you make a Kleenex dance? Put a little boogie in it!
+What do you get from a pampered cow? Spoiled milk!
+Where do baby cats learn to swim? The kitty pool.
+How can you tell it’s a dogwood tree? From the bark.
+What sound does the engine of a witch’s vehicle make? Broooom broooom!
+What do you call a fish wearing a bow tie? Sofishticated.
+What bone will a dog never eat? A trombone.
+Sundays are always a little sad, but the day before is a sadder day.
+Where do you learn to make a banana split? Sundae school.
+How do you row a canoe filled with puppies? Bring out the doggy paddle.
+Why is cold water so insecure? Because it’s never called hot.
+I don’t trust stairs. They’re always up to something.
+Why do bees have sticky hair? Because they use a honeycomb.
+What did Tennessee? The same thing as Arkansas.
+Why is it bad to iron your four-leaf clover? Because you shouldn’t press your luck.
+What rock group has four men who don’t sing? Mount Rushmore.
+Where do pirates buy hooks? The second hand store.
+Why didn’t the skeleton go on the rollercoaster? It didn’t have the guts.
+Why did the birds attack the dog? He was pure bread.
+What did the nose tell the finger? Stop picking on me.
+What do you call a sick lemon? Lemon-aid.
+What gets wetter the more it dries? A towel.
+What do you call a toothless bear? A gummy bear.
+Why can’t your hand be 12 inches long? Because then it would be a foot.
+What has four wheels and flies? A garbage truck.
+Why are pigs so bad at sports? Because they always hog the ball.
+Time flies like an arrow. Fruit flies like a banana.
+How do moths swim? Using the butterfly stroke.
+What’s an astronaut’s favorite part of a computer? The space bar.
+I hit in the head with a soda can. Thankfully it was a soft drink.
+What’s the name of my cheese? Nacho cheese.
+Knock, knock. Who’s there? Cows go. Cows go who? No, cows go moo!
+What’s the loudest pet you can own? A trumpet.
+What did the buffalo say to his son when he dropped him off at school? Bison.
+What does a pampered cow give? Spoiled milk.
+I made a whopping six figures last year. I also was fired from the toy factory for being too slow.
+Knock, knock. Who’s there? A little old lady. A little old lady who? Hey, you can yodel!
+Why did the teddy bear skip dessert? She was stuffed.
+What did the left eye say to the right? Something smells between us.
+What do you call a singing laptop? A Dell.
+What’s it called when a snowman throws a tantrum? A meltdown.
+What did the scarecrow win an award for? He was outstanding in his field.
+I don’t know much about the best things in Switzerland, but their flag is a big plus.
+I used to hate facial hair, but then it grew on me.
+I invented a pencil with an eraser on each end. There’s no point to it.
+What do you call it when Batman skips church? Christian Bale.
+Did you hear about the man who fell into an upholstery machine? He’s fully recovered.
+Why are skeletons so calm? Because nothing gets under their skin.
+What’s the astronaut’s favorite part of a computer? The spacebar.
+What did one ocean say to the other ocean? Nothing, they just waved.
+Did you hear about the power outlet who got into a fight with a power cord? He thought he could socket to him.
+Why are elevator jokes so good? They work on so many levels.
+Why did the nurse need a red pen? In case she needed to draw blood.
+Do you know the story about the chicken that crossed the border? Me neither, I couldn’t follow it.
+How can a leopard change his spots? By moving.
+Don’t trust atoms. They make up everything!
+What’s an astronaut’s favorite part of a computer? The space bar.
+I’m afraid of the calendar. Its days are numbered.
+Two guys walked into a bar. The third guy ducked.
+My wife said I should do lunges to stay in shape. That would be a big step forward.
+What did the zero say to the eight? That belt looks good on you.
+I got carded at a liquor store, and my Blockbuster card accidentally fell out. The cashier said never mind.
+How do trees get online? They just log on.
+How does the moon cut his hair? Eclipse it.
+Air used to be free at the gas station. Now it’s $1.50. You know why? Inflation.
+When I was a kid, my mother told me I could be anyone I wanted to be. Turns out, identity theft is a crime.
+I’ll call you later. Don’t call me later, call me Dad!
+When does a joke become a dad joke? When it becomes apparent.
+Which bear is the most condescending? A pan-duh.
+What kind of drink can be bitter and sweet? Reali-tea.
+Why do dads take an extra pair of socks when they golfing? In case they get a hole in one!
+Singing in the shower is fun until you get soap in your mouth. Then it’s a soap opera.
+Where do fruits go on vacation? Pear-is.
+Why do melons have weddings? Because they cantaloupe.
+What kind of cars do eggs drive? Yolkswagens.
+Why did the picture get arrested? It got framed.
+Why do M&Ms go to school? Because they want to be a Smartie.
+Knock knock. Who’s there? Tank. Tank who? You’re welcome.
+How do you protect a bagel? Lox it up!
+I like telling Dad jokes. Sometimes he laughs!
+Why did the stadium get hot after the game? All of the fans left.
+Why shouldn’t you enter into a contract with Wolverine? Because of his retractable clause.
+What kind of coffee does a vampire drink? De-coffin-ated.
+How do you keep a skunk from smelling? Hold its nose!
+What do you call a fish with two knees? A two-knee fish!
+Why can’t you tell a taco a secret? They tend to spill the beans! %%Cinco De Mayo
+Dogs can’t operate MRI machines. But catscan.
+I wondered why the frisbee kept getting bigger and bigger. Then it hit me.
+Why did the coach go to the bank? To get his quarter back.
+Why do dads take an extra pair of socks when they golfing? In case they get a hole in one!
+Singing in the shower is fun until you get soap in your mouth. Then it’s a soap opera.
+Where do fruits go on vacation? Pear-is.
+I was wondering why the ball kept getting bigger and bigger… // And then it hit me.
+Why do melons have weddings? Because they cantaloupe.
+What kind of cars do eggs drive? Yolkswagens.
+Every time I take my dog to the park, the ducks try to bite him. That’s what I get for buying a pure bread dog.
+Why does Snoop Dogg always carry an umbrella? Fo’ Drizzle.
+Why did the gym close down? It just didn’t work out.
+Two artists had an art contest. It ended in a draw.
+Where are average things manufactured? The Satisfactory.
+Want to hear a joke about construction? I’m still working on it.
+What did one hat say to the other? Wait here, I’m going on ahead!
+What cars do eggs drive? A Yolkswagen.
+What does a baby computer call his father? Data.
+After an unsuccessful harvest, why did the farmer decide to try a career in music? Because he had a ton of sick beets.
+I only seem to get sick on weekdays. I must have a weekend immune system.
+My friend was showing me his tool shed and pointed to a ladder. That’s my stepladder. he said. I never knew my real ladder.
+What do you call a Frenchman wearing sandals? Philippe Flop.
+Why is it so cheap to throw a party at a haunted house? Because the ghosts bring all the boos.
+I don’t get why Marvel doesn’t use the Hulk to advertise more. He’s basically one big Banner.
+What brand of underwear do scientists wear? Kelvin Klein.
+Which days are the strongest? Saturday and Sunday. The rest are weekdays.
+I just found out I’m colorblind. The news came out of the purple!
+Did you know your pupils are the last part to stop working when you die? They dilate.
+My wife asked me the other day where I got so much candy. I said, I always have a few Twix up my sleeve.
+How do cows stay up to date? They read the Moo-spaper.
+What’s the difference between a well-dressed man on a unicycle and a poorly-dressed man on a bicycle? Attire.
+I hate my job—all I do is crush cans all day. It’s soda pressing.
+Where do pirates get their hooks? Second hand stores.
+Of all the inventions of the last 100 years, the dry erase board has to be the most remarkable.
+In America, using the metric system can get you in legal trouble.
+What do you call a line of men waiting to get haircuts? A barberqueue.
+In fact, if you sneer at any other method of measuring liquids, you may be held in contempt of quart.
+Who were the greenest Presidents in US history? The bushes.
+My hotel tried to charge me ten dollars extra for air conditioning. That wasn’t cool.
+What do you call a beehive without an exit? Unbelievable.
+If I ever find the doctor who screwed up my limb replacement surgery…I’ll kill him with my bear hands.
+Did you know that the first french fries weren’t cooked in France? They were cooked in Greece.
+This morning, Siri said, Don’t call me Shirley. I accidentally left my phone in Airplane mode.
+It’s easy to convince ladies not to eat Tide Pods, but harder to deter gents.
+I asked my date to meet me at the gym but she never showed up. I guess the two of us aren’t going to work out.
+How do you find Will Smith in a snowstorm? You look for fresh prints.
+The difference between a numerator and a denominator is a short line. Only a fraction of people will understand this
+I found a wooden shoe in my toilet today. It was clogged.
+I just broke up with my mathematician girlfriend. She was obsessed with an X.
+I can’t take my dog to the pond anymore because the ducks keep attacking him. That’s what I get for buying a pure bread dog.
+To whoever stole my copy of Microsoft Office, I will find you. You have my Word.
+What’s Forrest Gump’s password? 1forrest1.
+I used to run a dating service for chickens. But I was struggling to make hens meet.
+If prisoners could take their own mug shots…They’d be called cellfies.
+Have you heard about those new corduroy pillows? They’re making headlines.
+If a pig loses its voice…does it become disgruntled?
+Wanna hear a joke about paper? Never mind. It’s tearable.
+A panic-stricken man explained to his doctor, You have to help me, I think I’m shrinking. Now settle down, the doctor calmly told him. You’ll just have to learn to be a little patient.
+What do you call a bundle of hay in a church? Christian Bale.
+A ship carrying red paint and a ship carrying blue paint collide in the middle of the ocean. Both crews were marooned.
+What is a guitar player’s favorite Italian food? Strum-boli.
+How does cereal pay its bills? With Chex.
+Have you heard about the restaurant on the moon? Great food, no atmosphere.
+I don’t trust stairs. They’re always up to something.
+People in Athens rarely get up before sunrise. Dawn is tough on Greece.
+Why’d the alternate universe Spider-Man do so well on his driving test? He’s an excellent parallel Parker.
+Never date a tennis player. Love means nothing to them.
+What’s a lawyer’s favorite drink? Subpoena colada.
+What did Yoda say when he saw himself in 4K? HDMI.
+What do you call a wizard who’s really bad at football? Fumbledore.
+How do nonbinary people hurt each other? They slash them. (They/them)
+I used to hate facial hair, but then it grew on me.
+What’s blue and not very heavy? Light blue.
+I don’t get why bakers aren’t wealthier. They make so much dough.
+I asked my wife if I was the only one she slept with. She said yes—the others were 7’s and 8’s.
+How do you make a tissue dance? You put a little boogie in it.
+How do flat-earthers travel? On a plane.
+I ordered a chicken and an egg from Amazon. I’ll let you know.
+Imagine if you walked into a bar and there was a long line of people waiting to take a swing at you. That’s the punch line.
+My wife left me because of my obsession with pasta. I’m feeling cannelloni right now.
+What’s an astronaut’s favorite part of the computer? The Space Bar.
+I was playing chess with my friend and he said, Let’s make this interesting. So we stopped playing chess.
+I was in a job interview the other day and they asked if I could perform under pressure. I said no, but I could perform Bohemian Rhapsody.
+Why didn’t the vampire attack Taylor Swift? She had bad blood.
+Today I’m attaching a light to the ceiling, but I’m afraid I’ll probably screw it up.
+I hate it when people say age is only a number. Age is clearly a word.
+I can’t take my dog to the pond anymore because the ducks keep attacking him. That’s what I get for buying a pure bread dog.
+Someone complimented my parking today! They left a sweet note on my windshield that said parking fine.
+I was excited to hear Apple might start selling its own cars until I learned they wouldn’t support windows.
+I just applied for a job down at the diner. I told them I really bring a lot to the table.
+Cop: I’m arresting you for downloading the entire Wikipedia. Man: Wait! I can explain everything!
+My friend couldn’t afford to pay his bill, so I sent him a Get Well Soon card.
+I’m Buzz Aldrin, second man to step on the moon. Neil before me.
+Why was 2019 afraid of 2020? Because they had a fight and 2021.
+Did you hear Bruce Springsteen changed the lyrics to one of his songs? What’s he going to change next—his hair? His clothes? His face?
+This year’s Fibonacci convention is going to be really special. Apparently it’s as big as the last two put together.
+An apple a day keeps the doctor away. At least it does if you throw it hard enough.
+I’m addicted to collecting vintage Beatles albums. I need Help.
+In 2017 I didn’t do a marathon. I didn’t do one in 2018, 2019, or 2020, either. This is a running joke.
+Not to brag but I made six figures last year. I was also named worst employee at the toy factory.
+Ever since we started quarantining, I’ve only been telling inside jokes.
+If you’re feeling depressed, try drinking a gallon of water before you go to sleep. It’ll give you a reason to get out of bed in the morning.
+My landlord told me we need to talk about the heating bill. Sure, I said. My door is always open.
+I built a model of Mount Everest and my son asked if it was to scale. No, I said. It’s to look at.
+What has five toes and isn’t your foot? My foot.
+My friend claims he glued himself to his autobiography. I don’t believe him, but that’s his story and he’s sticking to it.
+When I was a kid, my mother told me I could be anyone I wanted to be. Turns out, identity theft is a crime.
+What’s brown and sticky? A stick.
+My doctor told me I was going deaf. The news was hard for me to hear.
+A century ago, two brothers decided it was possible to fly. And as you can see, they were Wright.
+I’m reading a horror story in braille. Something bad is going to happen, I can just feel it.
+Anyone looking to buy a Delorean? Good shape, good mileage. Only driven from time to time
+During my calculus test, I had to sit between identical twins. It was hard to differentiate between them.
+Does anybody know where a guy can find a person to hang out with, talk to, and enjoy spending time with? I’m just asking for a friend.
+Why did the Invisible Man turn down a job offer? He couldn’t see himself doing it.
+When I die, I want to be cremated. It’s my last chance to have a smokin’ hot body.
+Just say NO to drugs! Well, if I’m talking to drugs, I probably already said yes.
+I once saw a one-handed man in a second-hand store. I told him, I don’t think they have what you’re looking for, sir.
+What do you call a sad cup of coffee? Depresso.
+What did one monocle say to the other monocle? Let’s get together and make a spectacle of ourselves.
+How come the Hulk doesn’t lose his pants when he transforms? The experiment altered his jeans.
+I didn’t want to believe that my dad was stealing from his job as a traffic cop, but when I got home, all the signs were there.
+I just spent $300 on a limo and learned it doesn’t come with a driver. I can’t believe I have nothing to chauffer it.
+What’s green and has wheels? Grass. I lied about the wheels.
+I have a joke about trickle down economics. But 99% of you will never get it.
+Just got back from a job interview where I was asked if I could perform under pressure. I said I wasn’t too sure about that but I could do a wicked Bohemian Rhapsody.
+What’s the best thing about living in Switzerland? I don’t know, but the flag is a big plus.
+At the job interview, they asked me, Where do you see yourself in five years? I told him, I think we’ll still be using mirrors in five years.
+A buddy asked how many fish I caught. I told him it’s not polite to fish and tell.
+How many clickbait articles does it take to change a lightbulb? The answer will shock you!
+How do you make a water bed bouncier? Add spring water.
+I always knock on the fridge door before opening it, just in case there’s a salad dressing.
+Where do dads store their dad jokes? In the dad-a-base.
+What kind of fruit do ghosts like? Boo-berries. %%Halloween
+I tried to start a professional hide and seek team, but it didn’t work out. Turns out, good players are hard to find.
+Women should not have children after 36—really, 36 children is enough.
+What happens when frogs park illegally? They get toad.
+Lance isn’t that common a name these days, but in medieval times, they were called lance-a-lot.
+I had an appointment to see my psychic next week, but she just called to cancel.
+She said I won’t be able to make it.
+I used to be addicted to soap, but I’m clean now.
+I wanted my kids to watch the orchestra, but I had to turn it off—too much sax and violins.
+A cop started crying while he was writing me a ticket. I asked him why and he said, It’s a moving violation.
+Swords will never go obsolete. They’re cutting edge technology.
+I asked the IT guy, How do you make a Motherboard? He said, I tell her about my job.
+What do you call it when James Bond takes a bath? Bubble 07.
+30 percent of pet owners let their pets sleep in their bed. I tried it and my goldfish died.
+What is the difference between a literalist and a kleptomaniac?
+I just found out Albert Einstein existed. My whole life I thought he was a theoretical physicist.A comma. A literalist takes everything literally. A kleptomaniac takes everything, literally.
+You used to be able to get air for free at gas stations, but now it’s a $1. That’s inflation for you.
+My dad was born a conjoined twin, but separated at birth. So I have an uncle, once removed.
+Why is it a bad idea to eat a clock? Because it’s so time-consuming.
+I went to a smoke shop only to discover it’d been replaced by an apparel store. Clothes, but no cigar.
+Why should you never brush your teeth with your left hand? Because a toothbrush works better.
+My grief counselor died the other day. He was so good at his job, I don’t even care.
+Give a man a plane ticket and he flies for the day. Push him out of the plane at 3,000 feet and he’ll fly for the rest of his life.
+As I get older, I remember all the people I lost along the way. Maybe a career as a tour guide was not the right choice.
+I was reading a great book about an immortal dog the other day. It was impossible to put down.
+What do you call someone who refuses to fart in public? A private tutor.
+I just read that someone in London gets stabbed every 52 seconds. Poor bastard.
+They say that breakfast is the most important meal of the day. Well, not if it’s poisoned. Then the antidote becomes the most important.
+The guy who stole my diary just died. My thoughts are with his family.
+Do you know the last thing my grandfather said to me before he kicked the bucket? Grandson, watch how far I can kick this bucket.
+If you donate a kidney, everybody loves you and you’re a total hero. But try donating five kidneys and suddenly everyone is yelling and the police get called.
+I have a fish that can breakdance. Only for ten seconds though, and only once.
+My friend said that if he went off a cliff, it would be on his own accord. It’s a good thing he drives a Civic.
+In my free time, I like to help blind people. Verb, not adjective.
+A doctor walks into a room with a dying patient and tells him, I’m sorry, but you only have ten left. The patient asks him, Ten what, Doc? Hours? Days? Weeks? The doctor calmly looks at him and says, Nine.
+I like to spend my weekends playing chess with elderly men in the park. But it’s becoming more difficult. You try finding exactly32 old guys.
+What do you call bears with no ears? B.
+What’s the difference between a wizard who raises the undead and a sexy vampire? One is a necromancer and the other is a neck romancer.
+A man walks into a magic forest and tries to cut down a talking tree. You can’t cut me down, the tree complains. I’m a talking tree! The man responds, You may be a talking tree, but you will dialogue.
+I heard Sony’s coming out with a new console during the pandemic...It’s called the Plaguestation 5.
+When my uncle Frank died, he wanted his remains to be buried in his favorite beer mug. His last wish was to be Frank in Stein.
+A man walks into a bar. The bartender asks, What do you want? The man says, Oh, just some fruit punch. The bartender sighs and shakes his head, If you want punch, you’re gonna have to wait in line. The man looks around, but there is no punchline.
+What’s worse than biting into an apple and finding a worm? Biting into an apple and finding half a worm.
+I just got my doctor’s test results and I’m really upset. Turns out, I’m not gonna be a doctor.
+My wife and I have decided not to have kids. The kids are taking it pretty badly.
+When does a joke become a dad joke? When it becomes apparent.
+My daughter just shrieked at me, Daaaaaad, you haven’t listened to a word I’ve said, have you? What an odd way to begin a conversation.
+I have a great joke about nepotism. But I’ll only tell it to my kids.
+Dad, can you explain to me what a solar eclipse is? No sun.
+What happened when the ten-year-old cannibal spilled his soup? His mother gave him an earful.
+I’d like to have kids one day. I don’t think I could stand them any longer than that, though.
+What did the buffalo say to his son when he dropped him off at school? Bison.
+I wonder what my parents did to fight boredom before the internet. I asked my eighteen brothers and sisters but they didn’t have any idea either.
+My parents raised me as an only child. Which really annoyed my younger brother.
+I tell dad jokes but I have no kids. I’m a faux pa!
+A kid decided to burn his house down. His dad watched, tears in his eyes. He put his arm around the mom and said, That’s arson.
+Today I decided to go visit my childhood home. I asked the residents if I could come inside because I was feeling nostalgic, but they refused and slammed the door on my face. My parents are the worst.
+What’s your name, son? The principal asked his student. The kid replied, D-d-d-dav-dav-david, sir. Do you have a stutter? the principal asked. The student answered, No sir, my dad has a stutter but the guy who registered my name was a real jerk.
+Concerned that his son was spending too much time on video games, a dad told him, When Abe Lincoln was your age, he was studying books by the light of the fireplace. Oh yeah? the son retorts. Well, when Abe Lincoln was your age, he was President of the United States.
+A father tells his son that he was adopted. I want to meet my biological parents, the son demands. We are your biological parents, the father responds. Now pack up, the new ones will pick you up in twenty minutes.
+A son tells his father, I have an imaginary girlfriend. The father sighs and says, You know, you could do better. Thanks Dad, the son says. That means a lot. The father shakes his head and goes, I was talking to your girlfriend.
+Yesterday, I was washing the car with my son. He said, Dad, can’t you just use a sponge?
+My dad died because he couldn’t remember his blood type. He kept insisting we be positive, but it’s just so hard without him.
+I tried to explain to my 4-year-old son that it’s perfectly normal to accidentally poop your pants. But he’s still making fun of me.
+I wasn’t close to my father when he died. Which is lucky because he stepped on a landmine.
+April showers bring May flowers, but what do May flowers bring? Pilgrims.
+What do you call a fake noodle? An Impasta.
+How do you make a tissue dance? Put a little boogie in it.
+What is a funny mountain called? Hill-arious.
+What do you call a song about a tortilla? A wrap.
+What’s Forrest Gump’s password? 1forrest1.
+Where do pirates buy hooks? The second hand store.
+The child refused to nap. She was found guilty of resisting a rest.
+Why did the tomato blush? It saw the salad dressing!
+Why is it bad to iron a four leaf clover? Because you should never press your luck.
+What did one hat say to the other? Wait here, I’m going on ahead!
+What keys unlock a banana? Mon-keys.
+What is a fancy fish called? So-fish-ticated.
+What’s blue and doesn’t weigh much? Light blue.
+Where do you learn to make a banana split? Sundae school.
+What happened to the frog that parked illegally? It got toad.
+What type of bear is toothless? A gummy bear.
+What cars do eggs drive? A Yolkswagen.
+Why didn’t the skeleton go on the rollercoaster? It didn’t have the guts.
+What did the cereal bring to the bank? Chex.
+How does the moon style his hair? Eclipse it.
+Why did the birds attack the dog? He was pure bread.
+What did one wall say to the other? Let’s meet at the corner.
+Why couldn’t the bicycle stand up alone? Because it was two tired.
+How do you make seven even? Take away the s.
+What’s it called when a snowman throws a tantrum? A meltdown.
+What did the scarecrow win an award for? He was outstanding in his field.
+What cars do sheep drive? Lamborghinis.
+How do cows learn about current events? They read the moo-spaper.
+How do you make a water bed bouncier? Fill it with Poland Spring water.
+I have a joke about construction, but I’m still working on it.
+At least I know I can always count on my fingers.
+I just gave my too weak notice at the gym.
+I bought Velcro sneakers, but they were a total rip-off!
+My dentist appointment is at tooth hurt-y.
+Apparently it was the fridge shrinking my clothes…not the dryer.
+Goodbye boiling water, you will be mist.
+All the fruits go on vacation in Pear-is.
+The dry-erase board is the most remarkable invention.
+I brought an egg to a comedy show and he cracked up.
+It takes a lot of guts to be an organ donor.
+That ghost was such a bad liar…I could see right through him! %%Halloween
+The football coach went to the bank to get his quarterback.
+Spiders are so smart, they know everything on the web. %%Halloween
+I used to have a fear of speed bumps, but I’m slowly getting over it.
+I had to get a neck brace last year and I haven’t looked back since.
+That circus fire was in tents.
+I don’t want to be friends with Dracula anymore, he’s such a pain in the neck!
+It was easy to stop women from eating Tide Pods, but I couldn’t deter gents.
+A joke becomes a dad joke once it is apparent.
+I don’t know much about the best things in Switzerland, but their flag is a big plus.
+That wedding was so emotional, even the cake was in tiers.
+Everyone’s sharing the rumor about butter, but I’m not about to spread it.
+I told a joke about chemistry, but it didn’t get a reaction.
+I’m a big dreamer, so I always hit the snooze button.
+I saw the Apple store get robbed…I guess that makes me an iWitness.
+That car seems nice, but the muffler looks exhausted.
+The ghost told me he’d bring the boos to the party tonight. %%Halloween
+I used to hate facial hair, but then it grew on me.
+That vampire should see a doctor…he’s always coffin. %%Halloween
+I’m following the seafood diet. I see food, then I eat it.
+Why was 6 afraid of 7? Because 7 ate 9.
+Dogs are not allowed to operate an MRI machine, but catscan!
+Don’t eat my cheese, that’s nacho cheese! %%Cinco De Mayo
+What computer is a singer? A Dell.
+My boss wished me a good day, so I went back home.
+Why do nurses always take the red crayons? They have to draw a lot of blood.
+I had a clock for breakfast. It was super time-consuming.
+What did one monocle say to the other monocle? Let’s meet up and make a spectacle of ourselves.
+It’s painful to say this, but I have a bad sore throat.
+What’s the least spoken language? Sign language.
+A cheese factory exploded downtown. Da brie is all over the streets!
+I’m so good at napping that I can do it in my sleep!
+I only know 25 letters of the alphabet. I don’t know y.
+What did one DNA molecule say to the other DNA molecule? How do these genes look on me?
+Don’t go in the grass without armor! It’s full of blades!
+Why did the invisible man decline the job offer? He couldn’t see himself doing it.
+How much money is it to park Santa’s sleigh? Nothing. It’s on the house.
+I’m so bored at work because all I do is crush cans all day. It’s soda pressing.
+What does a buffalo say goodbye to his son? Bison.
+3.14% of sailors are considered pi-rates.
+What animal is the worst at hide-and-seek? A leopard because he’s always spotted.
+What do you call someone who doesn’t have a nose or body? Nobody knows.
+What does garlic do before it showers? Takes its cloves off.
+Why did the dog float in the water? He was a good buoy.
+I went to the restaurant on the moon. The food was delicious, but there was no atmosphere.
+I invented a pencil with an eraser on each end. There’s no point to it.
+What has five toes, a heel, and isn’t your foot? My foot.
+Why didn’t Han Solo like his burger? It was too Chewie.
+What’s the astronaut’s favorite part of a computer? The spacebar.
+If you spell the words absolutely nothing backward, you get gnihton yletulosba, which ironically means…absolutely nothing.
+I had a joke about boxing, but I forgot the punchline.
+The farmers lost all their crops and decided to try a career in music instead. They just had too many sick beets.
+I once was addicted to soap, but I’m all clean now.
+The saying goes, An apple a day keeps the doctor away, but they keep calling me for my annual checkup.
+I’ll never trust atoms. They make up everything!
+I have a really funny joke about trickle-down economics, but there’s no use in telling it because 99% of you will never get it.
+I didn’t understand why the frisbee kept getting bigger. Then it hit me.
+I made a whopping six figures last year. I also was fired from the toy factory for being too slow.
+A guy walked into a bar…then he was disqualified from the limbo contest.
+I got an anonymous compliment about my parking skills today. It said, Parking fine.
+The calendar’s days are numbered. I’ll start planning the funeral.
+I shouldn’t have poured my root beer into a square glass. I hate beer!
+I used to fill my tires for free, but now it costs a dollar. I guess that’s the inflation everyone’s talking about.
+I’m such a morning person that I don’t even need an alarm clock. That and I drink a gallon of water before I go to bed.
+What came first, the chicken or the egg? I just ordered both on Amazon, so I’ll let you know.
+I’m the best at putting leaves in boiling water. It’s my special tea.
+When I was younger, my parents told me I can be anyone I dreamed of becoming. Then I learned the hard way that identity theft is a crime.
+Taylor Swift is immune to vampires. They know she has bad blood.
+The bartender broke up with her boyfriend, but he convinced her to give him one more shot.
+Did you hear about the new corduroy pillowcases? They’re making headlines.
+If the early bird catches the worm, call me a night owl because I prefer pancakes.
+The waiter asked if I wanted a box for my leftovers, but I told him I’m not into fighting.
+I accidentally took out my Blockbuster card at the bar. The bouncer said never mind.
+In a job interview, they asked me if I can perform under pressure. I told them I don’t know the lyrics.
+This guy was fired for always sweeping girls off their feet. He was a super-aggressive janitor.
+When two vegetarians get in a fight, is it still called beef?
+I heard that 5/4 of people are bad at fractions.
+I’m always getting sick during the week. I think I have a weekend immune system.
+Did you hear the joke about déjà vu? Did you hear the joke about déjà vu?
+Can a kangaroo jump higher than our house? Of course it can, a house can’t jump!
+Why does Peter Pan always fly? He Neverlands.
+What do you write on a rabbit’s birthday card? Hoppy Birthday!
+Where do sick boats go to get better? The boat doc.
+How does a banana answer a phone call? Yellow!
+If it’s raining cats and dogs, make sure you don’t step in a poodle!
+How does a bee brush its hair? It uses a honeycomb.
+What animal is dishonest? A lion.
+What has four wheels and flies? A garbage truck.
+Where do young trees learn math? Elementree school.
+What’s a lazy kangaroo called? A pouch potato.
+The finger was put in detention for always picking on the nose.
+Mount Rushmore is the only rock group that doesn’t sing or play musical instruments.
+What do tacos say in church? Lettuce pray! %%Cinco De Mayo
+What do Santa’s elves learn in Kindergarten? The elphabet.
+What’s the difference between a crocodile and an alligator? You will see one in a while and one later.
+What does a pampered cow make? Spoiled milk.
+What’s the Easter Bunny’s favorite music genre? Hip-hop.
+What is a pony with a sore throat called? A little hoarse.
+Where do baby cats swim? The kitty pool.
+How do astronauts organize a trip? They planet.
+I have a joke about pizza, but it’s really cheesy.
+What do clouds wear? Thunderwear.
+What’s brown and sticky? A stick.
+What game are tornadoes the best at? Twister.
+Why do giants sound so smart? They use big words!
+If a squirrel seems to like you, you must be a bit nutty.
+What’s a ghost’s favorite fruit? Boo-berries! %%Halloween
+What sound does the engine of a witch’s vehicle make? Broooom broooom!
+What’s orange and sounds just like a parrot? A carrot.
+Did you hear about the circus fire? It was in tents!
+How do you catch a squirrel? Climb a tree and act like a nut!
+Did you hear about the guy who invented Lifesavers? They say he made a mint!
+I told my wife she should embrace her mistakes. She gave me a hug.
+Why don’t eggs tell jokes? They might crack up!
+What did the big flower say to the little flower? Hi, bud!
+I went to buy some camouflage pants, but I couldn’t find any.
+What did the grape say when it got stepped on? Nothing, it just let out a little wine.
+I used to have a job at a calendar factory, but I got fired because I took a couple of days off.
+What do you call a snowman with a six-pack? An abdominal snowman!
+Why don’t skeletons fight each other? They don’t have the guts!
+Did you hear about the restaurant on the moon? Great food, no atmosphere!
+What did one wall say to the other wall? I’ll meet you at the corner!
+Why did the math book look sad? Because it had too many problems!
+What did one hat say to the other hat? You stay here, I’ll go on ahead!
+Why did the coffee file a police report? It got mugged!
+I was going to tell you a joke about time travel, but you didn’t like it.
+I used to be a baker, but I couldn’t make enough dough.
+Did you hear about the guy who got hit in the head with a can of soda? He was lucky it was a soft drink.
+I’m writing a book about glue, but I’m stuck on the first chapter.
+What did one plate whisper to the other plate? Dinner is on me.
+Why did the golfer bring two pairs of pants? In case he got a hole in one.
+Two sheep walk into a—baaaa.
+Stop looking for the perfect match; use a lighter.
+Try the seafood diet—you see food, then you eat it.
+Did you hear the rumor about butter? Well, I’m not going to go spreading it!
+What’s Forrest Gump’s password? 1forrest1
+What state is known for its small drinks? Minnesota.
+What does a nosey pepper do? It gets jalapeño business.
+If two vegetarians get in an argument, is it still called beef?
+I have a clean conscious—it’s never been used.
+I love telling Dad jokes. Sometimes, he even laughs.
+Can a kangaroo jump higher than a house? Of course, houses can’t jump.
+Why did the scarecrow win an award? He was outstanding in his field.
+What concert would cost only 45 cents? 50 Cent featuring Nickelback!
+How many telemarketers does it take to change a light bulb? Only one, but he has to do it during dinner.
+What are the strongest days of the week? Saturday and Sunday. All the others are weekdays.
+What did the seal with one fin say to the shark? If seal is broken, do not consume.
+How do you deal with a fear of speed bumps? You slowly get over it.
+How do you measure the mass of an influencer’s following? By Instagrams!
+How do you stop a bull from charging? Cancel its credit card.
+Am I the only man my wife has ever dated? Unfortunately, yes, she said the others were all nines or tens!
+What’s the difference between a man’s wallet before and after kids? There are pictures where the money used to be.
+I haven’t spoken to my wife in four years. I thought it would be rude to interrupt her!
+I wish my gray hair started in Las Vegas because what happens in Vegas, stays in Vegas.
+How do you follow Will Smith in the Mud? Follow the fresh prints.
+My kid is blaming me for ruining their birthday. That’s ridiculous, I didn’t even know it was today!
+My kid gave me a ’World’s Best Dad’ mug. At least she inherited my sense of humor.
+When a toddler reaches the why? stage, it’s like opening a bottle of champagne—once it’s uncorked, there’s no going back.
+What’s 90 degrees but covered with ice? The North and South Poles.
+What happened when the blue ship and the red ship collided at sea? Their crews were marooned.
+What’s the difference between the bird flu and the swine flu? One requires tweetment and the other an oinkment.
+What do you call a line of men waiting to get haircuts? A barberqueue.
+Why do seagulls fly over the sea? If they flew over the bay, they would be bagels.
+I’m thinking I should do lunges to stay in shape. That would be a big step forward.
+What did the baby corn say to the mama corn? Where’s popcorn?
+What vegetable is cool, but not that cool? Radish.
+What do you call two monkeys who share an Amazon Prime account? Prime mates.
+You can’t spell par entry without try.
+What do you call a beehive without an exit? Un-bee-lievable.
+Why did the football coach go to the bank? To get his quarter back.
+Why can’t a leopard hide? He’s always spotted.
+Air used to be free at the gas station, now it costs 2.50. You want to know why? Inflation.
+I tried to get a smart car the other day but they sold out too fast. Why? I guess I’m just a bit slow.
+Did you hear about the claustrophobic astronaut? He just wanted a bit more space.
+Why did the orange lose the race? It ran out of juice.
+How you fix a broken pumpkin? With a pumpkin patch.
+Why are fish so smart? They live in schools!
+What’s the best thing about Switzerland? I don’t know, but the flag is a big plus.
+Why did the man fall down the well? Because he couldn’t see that well!
+Why do peppers make such good archers? Because they habanero.
+What did the sink tell the toilet? You look flushed!
+Where do boats go when they’re sick? To the dock.
+What has ears but cannot hear? A cornfield!
+Can February March? No, but April May!
+Why was 6 afraid of 7? Because 7 ate nine!
+I’m so good at sleeping that I do it with my eyes closed.
+What do you call a pencil with two erasers? Pointless.
+Did you hear the one about the roof? Never mind, it’s over your head.
+What’s brown and sticky? A stick.
+I hated facial hair but then it grew on me.
+It really takes guts to be an organ donor.
+What did the plumber say to the singer? Nice pipes.
+I was going to tell a time-traveling joke, but you guys didn’t like it.
+I ordered a chicken and an egg online. I’ll let you know.
+I’m reading an anti-gravity book. I can’t put it down!
+I’d avoid the sushi if I were you. It’s a little fishy!
+What do houses wear? An address.
+What did the two pieces of bread say on their wedding day? It was loaf at first sight.
+What kind of shoes does a lazy person wear? Loafers.
+What did the ocean say to the beach? Nothing, it just waved.
+What happens when a snowman throws a tantrum? He has a meltdown.
+Why’d the fisherman order the halibut? Just for the halibut!
+Why is Peter Pan always flying? Because he Neverlands.
+What do you call a sleeping bull? A bulldozer.
+How do you throw a party in outer space? You planet.
+Why was the broom late to class? It over-swept.
+How do you make an octopus laugh? With ten-tickles!
+What do you say to a rabbit on its birthday? Hoppy Birthday!
+What type of tree fits in your hand? A palm tree.
+Why couldn’t the bicycle stand up by itself? It was two tired!
+Wanna hear a joke about construction? I’m still workin’ on it!
+What do you call a fake noodle? An impasta.
+How does a lawyer say goodbye? I’ll be suing ya!
+You can’t trust atoms. They make up everything!
+What made the tomato blush? It saw the salad dressing.
+Can I dive in this pool? It deep-ends.
+What did the buffalo say to its son when he left? Bison!
+Why do vampires always seem sick? They’re coffin. %%Halloween
+What musical instrument do you find in the bathroom? A tuba toothpaste!
+Which state has the most streets? Rhode Island.
+How do astronomers organize a party? They planet.
+Why do bees have sticky hair? Because they use a honeycomb.
+Why do melons have weddings? They cantaloupe!
+What did the police officer say to her belly button? You’re under a vest!
+What do you call a fibbing cat? A lion.
+If a child refuses to nap, are they guilty of resisting a rest?
+Did you hear about the outlet who got in a fight with the power cord? He thought he could socket to him.
+What do you call a fancy fish? So-fish-ticated.
+If April showers bring May flowers, what do May flowers bring? Pilgrims.
+How do you make 7 even? You take away the s.
+What kind of cars do eggs drive? Yolkswagens.
+Where do math teachers go on vacation? Times Square.
+Why was the stadium so hot after the game? Because all the fans left.
+The coach went to the bank to get his quarterback.
+I asked my dog what’s two minus two. He said nothing.
+The first thing Santa’s elves learn in school is their elf-abet. %%Christmas
+Ghosts are bad liars because you can see right through them. %%Halloween
+Shouldn’t the roof of your mouth actually be called the ceiling?
+All vampires keep their money in a special place—the blood bank.
+The pony couldn’t sing because it was a little horse.
+RIP boiling water, you will be mist.
+I told my doctor I heard buzzing, but she said it’s just a bug that’s going around.
+I ate a clock the other day. It was very time consuming.
+I once wrote a song about a tortilla, but it’s more of a wrap.
+You can tell it’s a dogwood tree from its bark.
+When does a joke turn into a dad joke? When it becomes apparent.
+They say that 3/2 people are bad at fractions.
+Dogs can’t operate MRI machines but catscan.
+A witch’s vehicle goes brrrroom brrrroom!
+I’m worried for the calendar because its days are numbered.
+Dear Math, it’s time to grow up and solve your own problems.
+I only know 25 letters of the alphabet—I don’t know y.
+I just don’t trust stairs, they’re always up to something.
+I used to play piano by ear, but now I use my hands.
+How do celebrities stay cool? They have many fans.
+Why did the picture go to prison? Because it was framed.
+How does a hurricane see? With one eye.
+Where do polar bears keep their money? The snow bank.
+What’s a tornado’s favorite game? Twister!
+How does the moon cut his hair? Eclipse it.
+What do you call a funny mountain? Hill-arious.
+What gets wetter the more it dries? A towel.
+What did the banana say to the boy? Nothing, bananas can’t talk!
+What rock group has four men who don’t sing? Mount Rushmore.
+My boss told me to have a good day, so I went home!
+What do you call cheese that isn’t yours? Nacho cheese.
+Did you get your haircut? No, I got them all cut.
+I was wondering why the frisbee kept getting bigger and bigger. Then it hit me.
+Wanna hear a joke about paper? Never mind. It’s tearable.
+How many apples grow on a tree? All of them!
+I talk to myself because sometimes I just need expert advice.
+I used to be addicted to the hokey-pokey until I turned myself around.
+What do you call someone who tells dad jokes but isn’t a dad? A faux pa.
+I could tell a joke about pizza, but it’s a little cheesy.
+If you see a crime at an Apple store, are you an iWitness?
+I hate Velcro. It’s a rip off.
+Spring is here! I got so excited that I wet my plants.
+I had to sell my vacuum cleaner. All it was doing was gathering dust.
+Do you know how many people are dead at a cemetery? All of them.
+I’ll call you later. Don’t call me later, call me Dad.
+If the early bird gets the worm, I’ll sleep in until there’s pancakes.
+The wedding was so beautiful, even the cake was in tiers.
+Why are spiders so smart? They can find everything on the web.
+What do you call a toothless bear? A gummy bear!
+What do you give a sick lemon? Lemon-aid.
+What did the nose tell the finger? Stop picking on me!
+Why can’t your hand be 12 inches long? Because then it would be a foot.
+What kind of car does a sheep like to drive? A lamborghini.
+What key is used to open bananas? A mon-key.
+What has four wheels and flies? A garbage truck.
+How do you talk to a giant? You use big words!
+How do you make a tissue dance? Put a little boogie in it!
+What kind of milk comes from a pampered cow? Spoiled milk.
+What’s a sea monster’s favorite lunch? Fish and ships.
+What do you call an alligator in a vest? An investigator.
+Why are pigs so bad at sports? They always hog the ball.
+Why shouldn’t you tell an egg a joke? It’ll crack up.
+What’s a foot long and slippery? A slipper.
+What’s a ninja’s favorite type of shoes? Sneakers!
+What’s orange and sounds like a parrot? A carrot!
+How does a penguin build a house? Igloos it together.
+Why is no one friends with Dracula? He’s a pain in the neck.
+Where do you learn all about ice cream? Sundae school.
+Which bear is the most condescending? A pan-duh!
+What kind of noise does a witch’s vehicle make? Brrrroooom, brrroooom.
+What’s brown and sticky? A stick.
+Two guys walked into a bar. The third guy ducked.
+Did you hear about the actor who broke his leg onstage? He’s still in the cast.
+How do you get a country girl’s attention? A tractor.
+Why did the pharmacist walk on her tiptoes? She didn’t want to wake the sleeping pills.
+I wanted to buy a pair of camouflage pants, but I couldn’t find any.
+Why are elevator jokes so classic and good? They work on many levels.
+I have an inferiority complex, but it’s not a very good one.
+What do you call a pudgy psychic? A four-chin teller.
+I had a date last night and it was perfect. Tomorrow, I’ll have a fig.
+What did the police officer say to his belly-button? You’re under a vest.
+What do you call it when a group of apes starts a company? Monkey business.
+My wife asked me to stop singing Wonderwall to her. I said Maybe...
+What kind of drink can be bitter and sweet? Reali-tea.
+What do you call a naughty lamb dressed up like a skeleton for Halloween? Baaad to the bone.
+Why did the lobster blush? Because it saw the ocean’s bottom!
+Want to know why nurses like red crayons? Sometimes they have to draw blood.
+What would the Terminator be called in his retirement? The Exterminator.
+What did Tennessee? The same thing as Arkansas.
+My wife asked me to go get 6 cans of Sprite from the grocery store. I realized when I got home that I had picked 7 up.
+Why do bees have sticky hair? Because they use a honeycomb.
+Why do some couples go to the gym? Because they want their relationship to work out.
+What do you call an angry musician flipping someone off? A song bird.
+Did you hear about the kidnapping at school? It’s fine, he woke up.
+How can you tell it’s a dogwood tree? By the bark.
+My boss told me to have a good day, so I went home.
+Our vacuum cleaner is getting old. It’s just gathering dust.
+Why did the man fall down the well? Because he couldn’t see that well.
+Why is Peter Pan always flying? Because he Neverlands.
+Which state has the most streets? Rhode Island.
+What do you call 26 letters that went for a swim? Alphawetical.
+What’s the name of a very polite, European body of water? Merci.
+Why was the color green notoriously single? It was always so jaded.
+I used to hate facial hair, but then it grew on me.
+I want to make a brief joke, but it’s a little cheesy.
+Why did the coach go to the bank? To get his quarter back.
+How do celebrities stay cool? They have many fans.
+Sundays are always a little sad, but the day before is a sadder day.
+5/4 of people admit they’re bad at fractions.
+Why did the bedding hide their relationship? They just wanted something pillow-key!
+You’re American when you go into a bathroom and when you come out, but what are you while you’re in the bathroom? European.
+I’ve been thinking about taking up meditation. I figure it’s better than sitting around doing nothing.
+What did the flowers do when the bride walked down the aisle? They rose.
+It takes guts to be an organ donor.
+What do you get from a pampered cow? Spoiled milk.
+What does Rockin’ Robin do when she’s bored? Tweet.
+I lost my job at the bank on my first day. A woman asked me to check her balance, so I pushed her over.
+Why did Waldo go to therapy? Because he needed to find himself.
+How do you row a canoe filled with puppies? Bring out the doggy paddle.
+Singing in the shower is fun until you get soap in your mouth. Then it becomes a soap opera.
+Why were the utensils stuck together? They were spooning.
+What’s a crafty dancer’s favorite hobby? Cutting a rug.
+How does a penguin build his house? Igloos it together.
+What kind of music do chiropractors like? Hip pop.
+Where do you learn to make ice cream? At sundae school.
+What kind of shoes does a lazy person wear? Loafers.
+Why is cold water so insecure? Because it’s never called hot.
+Justice is a dish best served cold. If it were served warm, it would be just-water.
+I was going to tell a time-traveling joke, but you guys didn’t like it.
+Shouldn’t the roof of your mouth actually be called the ceiling?
+Why did the baby strawberry cry? Because its mother was in a jam.
+Why couldn’t the toilet paper cross the road? Because it got stuck in a crack. %%Cross the road
+Stop looking for the perfect match…use a lighter.
+I told my doctor I heard buzzing, but he said it’s just a bug going around.
+What kind of car does a sheep like to drive? A Lamborghini.
+What do you call someone who won’t stick to a diet? A desserter.
+What did the accountant say while auditing a document? This is taxing.
+What did the two pieces of bread say on their wedding day? It was loaf at first sight.
+If you see a burglary at an Apple store, you become an iWitness.
+If the early bird gets the worm, I’ll sleep in until there’s pancakes.
+Why do melons have weddings? Because they cantaloupe.
+I signed up for a marathon, but how will I know if it’s the real deal or just a run through?
+When you have a bladder infection, urine trouble.
+What did the drummer call his twin daughters? Anna One, Anna Two!
+What did the juicer say to the orange during self-quarantine? Can’t wait to squeeze you!
+What do you call a toothless bear? A gummy bear!
+Want to hear a joke about construction? I’m still working on it.
+Someone told me that I should write a book. I said, That’s a novel concept.
+Two goldfish are in a tank. One says to the other, Do you know how to drive this thing?
+Why did the pony ask for a glass of water? Because it was a little horse.
+What’s Forrest Gump’s password? 1forrest1
+I tell dad jokes, but I don’t have any kids. I’m a faux pa.
+What does a nosey pepper do? It gets jalapeño business.
+How can you mend a broken pumpkin? Use a pumpkin patch.
+If a child refuses to nap, are they guilty of resisting a rest?
+Why do dads feel the need to tell such bad jokes? They just want to help you become a groan up.
+I know a lot of jokes about retired people, but none of them work.
+Why are spiders so smart? They can find everything on the web.
+What do you call spiders who just got married? Newly-webs.
+RIP boiled water—you will be mist.
+What do you call two octopuses that look the same? Itenticle.
+What has one head, one foot, and four legs? A bed.
+Sore throats are a pain in the neck.
+What does a house wear? Address.
+Why did the scarecrow win an award? He was out standing in his field.
+What is a scarecrow’s favorite fruit? Straw-berries.
+What’s red and smells like blue paint? Red paint.
+My son asked me to put his shoes on, but I don’t think they’ll fit me.
+I’ve been bored recently, so I decided to take up fencing. The neighbors keep demanding that I put it back.
+How do you know when a chicken is evil? It lays deviled eggs.
+What do you call an unpredictable camera? A loose Canon.
+I didn’t get a haircut, I got them all cut.
+Which U.S. state is known for its especially small soft drinks? Minnesota.
+What do sprinters eat before a race? Nothing—they fast.
+What did one Dorito farmer say to the other? Cool Ranch!
+How do cows shop? From cattle-logs.
+I’m so good at sleeping, I can do it with my eyes closed.
+People are usually shocked that I have a Police record. But I love their greatest hits!
+I told my girlfriend she drew on her eyebrows too high. She seemed surprised.
+What do you call a fibbing cat? A lion.
+Why shouldn’t you write with a broken pencil? Because it’s pointless.
+I like telling Dad jokes…sometimes he laughs.
+How do you weigh a millennial? In Instagrams.
+The wedding was so beautiful, even the cake was in tiers.
+What’s the most patriotic sport? Flag football.
+Why were spectators confused by the koala’s self-portrait? It was bear.
+Why did the envelope take so long to get ready? It had to get addressed.
+What does a karate master get rewarded with while driving? A seat belt.
+What do you call a baby sheep that knows karate? A lamb chop.
+What did the husband say to his wife right after getting LASIK surgery? Aren’t you a sight for sore eyes?
+Why are pigs bad drivers? Because they hog the road.
+What do lions use to look at their manes? Mirroars.
+What did the dad say when his golden retriever was caught eating a hot dog? It’s a dog eat dog world out there.
+Do mascara and lipstick ever argue? Sure, but then they makeup.
+What piece on the playground is always exhausted? The tire swing.
+Why did two tall people get along so well? They could really see eye to eye.
+Why was the gossip disliked at the coffee shop? She always spilled the tea.
+What does a writer have in common with a football player? Anxiety over a rough draft.
+Where do wasps like to get lunch? A bee-stro.
+Is there anything worse than when it’s raining cats and dogs? Yes! Hailing taxis.
+Why would doors do well on social media? Everyone looks for their handles.
+Why did the physicist and the biologist break up? Because they had no chemistry.
+If you feel like someone is watching you, you’re not alone.
+Which bathroom appliance would be the worst life preserver? The sink.
+Why was the dad sitting on a pack of playing cards? His kid asked him to sit on the deck.
+How do birds learn how to fly? They wing it!
+What kind of bird is always getting hurt? The owl.
+What’s either a really gross animal issue OR an impressive, magical school? Hogwarts.
+How does Darth Vader like his toast? On the dark side.
+What did the dishwasher say to the oven after a productive day? You’ve been on fire!
+Why did the tomato blush? Because it saw the salad dressing.
+Why did the cashier rip money in half? They were asked to break a bill.
+What did one furniture maker say to another during a tense discussion? Let’s table this.
+I was going to tell a joke about water, but it was too tasteless.
+Why couldn’t the duck be quiet? Because it was addicted to quack.
+Why was the ghost so tired? He worked the graveyard shift. %%Halloween
+Why do pancakes always win at baseball? They have the best batter.
+Why did the baseball player get arrested? Because he stole second base.
+Why couldn’t the couple get married at the library? It was all booked up.
+Why did the pug buy a clock? It wanted to be a watchdog.
+Where do hamburgers go to dance? The meatball.
+How did the dad prank his daughter using fake dog poop on April Fools Day? He told her to look out for her new sham-poo in the shower.
+What did the air conditioner say when it met a celebrity? I’m a big fan.
+What was Sherlock Holmes’ favorite protein source? Mystery meat.
+What did the dryer say to the boring duvet cover that just got out of the washer? Don’t be such a wet blanket.
+Why couldn’t the bike stand up on its own? Because it was too tired.
+Why was the cow such a heartthrob on the farm? He was a s-moo-th talker.
+What’s a writer’s favorite train station? Penn Station.
+What do you call a gnat with a sore throat? A hoarse fly.
+What was said about the messy, angry man who was eating a can of Pringles? He’s got a chip on his shoulder.
+What’s it called when kittens get stuck in a tree? A cat-astrophe.
+What kind of shape may have been knighted? Sir-cles.
+Why is sand so optimistic? It has a can-dune attitude.
+What has four wheels and flies? A garbage truck.
+What part of the museum makes everyone sneeze? The sta-tues.
+What did the baker say when she won an award? It was a piece of cake.
+Why couldn’t the couple respond right away when looking at wedding venues? They were engaged.
+What is Marco’s favorite clothing store? Polo.
+What do you call it when a lawyer takes a test early in the morning? A breakfast bar.
+What do frogs use to track their exercise? Fit (rib)bits.
+How do frogs invest their money? They use a stock croaker.
+Why did police arrest the turkey? They suspected fowl play.
+What kind of cleaning product feels a lot of motivation in life? All-purpose.
+Where was the dripping coming from in the fridge? The leeks.
+Why was the hockey player gifted a new cap? He was known for his hat tricks.
+What vegetable is kind to everyone? The sweet potato.
+How was the handsome runner described? Dashing.
+What animals are the best to call if you get locked out of your house? Monkeys.
+What did the geometry teacher say when the class had trouble solving a problem? Let’s try a different angle.
+Why don’t phones ever go hungry? They have plenty of apps to choose from.
+Why couldn’t the family leave the room after playing with Legos? They were blocked.
+What makes a basketball court trendy and accessorized? The hoops.
+What did the sapphire’s best friend tell her? You’re a real gem.
+Getting paid to sleep is a true dream job.
+Did you hear about the bossy man at the bar? He ordered everyone around.
+What do you give the dentist of the year? A little plaque.
+Why did the deer go to the dentist? It had buck teeth.
+Why did the Oreo go to the dentist? Because it lost its filling.
+What happens when doctors get frustrated? They lose their patients.
+Why was the traffic light late to work? It took too long to change.
+Did you hear about the guy who was afraid of hurdles? He got over it.
+Why didn’t the sun go to college? It already had a million degrees.
+Did you hear about the guy who drank invisible ink? He’s at the hospital waiting to be seen.
+What do you call a can opener that doesn’t work? A can’t opener.
+What do lawyers wear to work? Law suits.
+I used to be a banker, but I lost interest.
+Why did the computer catch cold? It left a window open.
+What do computers eat for a snack? Microchips.
+Why did the computer go to bed? It needed to crash.
+Why did the employee get fired from the keyboard factory? He wasn’t putting in enough shifts.
+How do trees get on the internet? They log in.
+Why did the computer get glasses? To improve its website.
+What kind of bird works on a construction site? A crane.
+How much money does a skunk have? Only one scent.
+Why did the watch go on vacation? Because it needed to unwind.
+What does a painter do when he gets cold? Puts on another coat.
+How do you tell a scientist that they have bad breath? Offer them an experi-mint.
+How did the barber win the race? He knew a shortcut.
+Why did the roofer go to the doctor? He had shingles.
+Dogs can’t operate MRI machines, but cats-can.
+What does a librarian use to go fishing? A bookworm.
+What did the roof say to the shingle? The first one is on the house.
+Why did the tailor get fired? He wasn’t a good fit.
+What kind of bug can tell time? A clock-roach.
+Why did the girl toss a clock out the window? She wanted to see time fly.
+When does Friday come before Thursday? In the dictionary.
+How many telemarketers does it take to change a light bulb? Only one, but he has to do it while you are eating dinner.
+How many narcissists does it take to screw in a light bulb? One. The narcissist holds the light bulb while the rest of the world revolves around him.
+How many DIY buffs does it take to change a light bulb? One, but it takes two weeks and four trips to the hardware store.
+How many paranoids does it take to change a light bulb? Who wants to know?
+I read that by law you must turn on your headlights when it’s raining in Sweden, but how am I supposed to know when it’s raining in Sweden?
+I was addicted to the hokey pokey…but I turned myself around.
+I don’t trust stairs. They are always up to something.
+Today, my son asked, Can I have a bookmark? I burst into tears—11 years old and he still doesn’t know my name is Brian.
+When I was a kid, my dad got fired from his job as a road worker for theft. I refused to believe he could do such a thing, but when I got home, the signs were all there.
+Why didn’t Han Solo enjoy his steak dinner? It was Chewie.
+Why don’t pirates take a bath before they walk the plank? They just wash up on shore.
+Why do you never see elephants hiding in trees? Because they’re so good at it.
+Did you hear about the racing snail who got rid of his shell? He thought it would make him faster, but it just made him sluggish.
+A turtle is crossing the road when he’s mugged by two snails. When the police ask him what happened, the shaken turtle replies, I don’t know. It all happened so fast.
+Did you hear about the guy who froze to death at the drive-in? He went to see Closed for the Winter.
+We all know about Murphy’s Law: Anything that can go wrong will go wrong. But have you heard of Cole’s Law? It’s thinly sliced cabbage.
+When does a joke become a dad joke? When it becomes apparent.
+I had a happy childhood. My dad used to put me in tires and roll me down hills. Those were Goodyears.
+What invention allows us to see through walls? Windows.
+I know a bunch of good jokes about umbrellas, but they usually go over people’s heads.
+The bank keeps calling me to give me compliments. They say I have an outstanding balance.
+What is the most popular fish in the ocean? A starfish.
+Barbers…you have to take your hat off to them.
+What did one plate say to another plate? Tonight, dinner’s on me.
+Did you hear about the surgeon who enjoyed performing quick surgeries on insects? He did one on the fly.
+What’s a vampire’s favorite ship? A blood vessel. %%Halloween
+There’s only one thing I can’t deal with, and that’s a deck of cards glued together.
+The past, the present, and the future walked into a bar. It was tense.
+Son: Dad, I’m hungry. Dad: Hi hungry, I’m Dad.
+Dad: Did you hear about the kidnapping at school? Son: No. What happened? Dad: The teacher woke him up.
+Daughter: I have a lot of friends named Nathan. There’s Nathan Miller, Nathan Radcliff, Nathan Lewis… Me: When they are together, do you call them the United Nathans?
+What’s the least-spoken language in the world? Sign language.
+What do you call a hippie’s wife? Mississippi.
+I searched for a lighter on Amazon, but all I could find were 6,000 matches.
+I sold our vacuum cleaner; it was just gathering dust.
+What did the evil chicken lay? Deviled eggs.
+Did you hear they arrested the devil? Yeah, they got him on possession.
+A friend of mine didn’t pay his exorcist. He got repossessed.
+How do you make holy water? You boil the hell out of it.
+What sound does a witch’s car make? Broom broom! %%Halloween
+I want to go on record that I support farming. As a matter of fact, you could call me protractor.
+What’s the best way to watch a fly-fishing tournament? Live stream.
+How do you tell the difference between an alligator and a crocodile? You will see one later and one in a while.
+Did you hear about the crustacean accused of promoting his own shellfish interests?
+Did you hear about the bankrupt poet who ode everyone?
+Did you hear about the shepherd who drove his sheep through town and was given a ticket for making a ewe turn?
+Did you hear about the cat who ate a ball of yarn? She had mittens.
+Did you hear about the claustrophobic astronaut? He just wanted a little more space.
+Why did the man name his dogs Rolex and Timex? Because they were watchdogs.
+What do you call a dog that can do magic? A Labracabrador.
+Why do dogs float in water? Because they are good buoys.
+What happens when it rains cats and dogs? You have to be careful not to step in a poodle.
+What do you call 50 pigs and 50 deer? 100 sows and bucks.
+Why do cows wear bells? Because their horns don’t work.
+What do you call a fish with no eye? A fsh.
+Police arrested a bottle of water because it was wanted in three different states: solid, liquid, and gas.
+What do you call a lazy kangaroo? Pouch potato.
+Why is grass so dangerous? Because it’s full of blades.
+What is the Easter bunny’s favorite type of music? Hip-hop.
+A friend of mine is known for sweeping girls off their feet. He’s an extremely aggressive janitor.
+I’m an expert at picking leaves and heating them in water. It’s my special tea.
+My son’s fourth birthday was today. When he came to see me, I didn’t recognize him at first. I had never seen him be four.
+I recently went to the World’s Tiniest Wind Turbine exhibit. Honestly, not a big fan.
+I was out on a walk when I saw a sign that said, Man wanted for robbery. So I went in and applied for the job.
+How long should socks be? Twelve inches, so you can fit in one foot.
+Did you hear the joke about experiencing déjà vu? Did you hear the joke about experiencing déjà vu?
+A bartender broke up with her boyfriend, but he kept asking her for another shot.
+I’m reading a novel where the main character has strained the muscles around his spine. That’s his back story.
+My doctor told me I’ve really grown as a person. Well, her exact words were that I gained excess weight.
+What do you call someone who always states the obvious? Someone who always states the obvious.
+Scientists have discovered what is believed to be the world’s largest bedsheet. More on this story as it unfolds.
+3.14 percent of sailors are pi-rates.
+You can’t plant flowers if you haven’t botany.
+What did the French chef give his wife for Valentine’s Day? A hug and a quiche.
+A ham sandwich walks into a bar and orders a beer. The bartender says, Sorry, we don’t serve food here.
+A couple of cups of yogurt walk into a country club. We don’t serve your kind here, the bartender says. Why not? one yogurt asks. We’re cultured.
+A brain walks into a bar and takes a seat. I’d like some wings and a pint of beer, please, it says. Sorry, but I can’t serve you, the bartender replies. You’re out of your head.
+A pirate walks into a bar with a paper towel on his head. The bartender says, What’s with the paper towel? The pirate says, Arrr! I’ve got a Bounty on me head!
+A guy walks into a bar, and there’s a horse serving drinks. The horse asks, What are you staring at? Haven’t you ever seen a horse tending bar before? The guy says, It’s not that. I just never thought the parrot would sell the place.
+Why did Beethoven get rid of his chickens? All they said was, Bach, Bach, Bach…
+What did one DNA say to the other DNA? Do these genes make me look fat?
+What do youneed to make a small fortune on Wall Street? A large fortune.
+How does the man in the moon get his hair cut? Eclipse it.
+Did you hear about the restaurant on the moon? Great food, no atmosphere.
+Did you hear the one about the kid who started a business tying shoelaces on the playground? It was a knot-for-profit.
+My kid wants to invent a pencil with an eraser on each end, but I just don’t see the point.
+Teacher: There are two words I don’t allow in my class. One is gross, and the other is cool. Johnny: So, what are the words?
+Why should you never mention the number 288? It’s two gross
+I spent a lot of time, money, and effort childproofing my house, but the kids still get in.
+A cheese factory exploded in France. Da brie is everywhere!
+Did you hear the rumor about butter? Well, I’m not going to spread it!
+Why do melons have weddings? Because they cantaloupe.
+What do Bostonians call a fake noodle? An impasta.
+A college education now costs $100,000, but it produces three very proud people: the student, his mama, and his pauper.
+My son has his BA and his MA, but his P­A still supports him.
+What does a mobster buried in cement soon become? A hardened criminal.
+What does idk stand for? Everyone I ask says, I don’t know.
+Why was the pig covered in ink? Because it lived in a pen.
+Did you hear about the guy who stole 50 cartons of hand sanitizer? They couldn’t prosecute—his hands were clean.
+Why was the rookie police officer assigned to hunt the cannibal? The more seasoned officers had already been eaten.
+What do you call a snitching scientist? A lab rat.
+What’s the difference between a man wearing pajamas on a bicycle and a guy wearing a tuxedo on a unicycle? Attire.
+It’s a shame that the Beatles didn’t make the submarine in that song green. That would’ve been sublime.
+Did you hear about the aquatic sea mammals that escaped from the zoo? It was otter chaos.
+What did the skeleton order with its beer? A mop.
+Why do nurses like red crayons? Sometimes they have to draw blood.
+How much do I love crunchy tacos? From my head tomatoes. %%Cinco De Mayo
+What kind of spells do leprechauns use? Lucky Charms.
+What do you call a bear with no teeth? A gummy bear.
+My IQ test results came back. They were negative.
+What do you get when you cross a polar bear with a seal? A polar bear.
+Did you hear about the nurse who was chewed out by the doctor because she was absent without gauze?
+If athletes get athlete’s foot, what do astronauts get? Missile toe.
+My wife asked me to sync her phone, so I threw it into the ocean.
+My wife is really mad that I have no sense of direction. I packed up my stuff and right.
+What did one cannibal say to the other while they were eating a clown? Does this taste funny to you?
+Do I enjoy making courthouse puns? Guilty.
+What do you call someone with no body and no nose? Nobody knows.
+You know, people say they pick their nose, but I feel like I was just born with mine.
+In a freak accident today, a photographer was killed when a huge lump of cheddar landed on him. To be fair, the people who were being photographed did try to warn him.
+Can February March? No, but April May.
+Not sure if you have noticed, but I love bad puns. That’s just how eye roll.
+If you see a robbery at an Apple store, does that make you an iWitness?
+What did the drummer call his twin daughters? Anna one, Anna two…
+What’s a bad wizard’s favorite computer program? Spell check.
+I was just reminiscing about the beautiful herb garden I had when I was growing up. Good thymes.
+I began to read a horror novel in braille. Something bad is about to happen—I can feel it.
+Why do pumpkins sit on porches? They have no hands to knock on the door.
+My friend wants to become an archaeologist, but I’m trying to put him off. I’m convinced his life will be in ruins.
+I got hit in the head with a can of Coke today. Don’t worry, I’m not hurt. It was a soft drink.
+Cooking out this weekend? Don’t forget the pickle. It’s kind of a big dill.
+Justice is a dish best served cold. If it were served warm, it would be justwater.
+What’s orange and sounds like a parrot? A carrot.
+A steak pun is a rare medium done well.
+Why did the raisin go out with the prune? Because he couldn’t find a date.
+What’s brown and sticky? A stick.
+My dog accidentally swallowed a bunch of Scrabble tiles. I think this could spell disaster.
+I wondered why the ball was getting bigger. Then it hit me.
+I had a date last night. It was perfect. Tomorrow, I’ll try a grape.
+Armed robbers—some say they’re a drain on society, but you’ve got to give it to them.
+It hurts me to say this, but I have a sore throat.
+I know a surgeon who puts organs back in upside down. I told him that’s not funny, but he said it was an inside joke.
+My girlfriend says it’s either her or my career as a news reporter. I have some breaking news for her.
+Inflation is really getting out of hand, but that’s just my five cents.
+I can guess what people do for a living just by looking at their hands. I mean, I’m usually wrong, but I can guess.
+I’ve been breeding racing deer. Just trying to make a quick buck.
+How many mystery writers does it take to change a light bulb? Two: One to screw it in most of the way and another to give it a surprise twist at the end.
+My dentist offered me dentures for only a dollar. It sounded like a good deal at the time, but now I have buck teeth.
+"""
+
+def parse_joke_line(line, joke_id):
+    line = line.strip()
+    if not line:
+        return None
+
+    # Replace curly apostrophes with straight ones FIRST
+    text_to_process = line.replace("\u2019", "'").replace("’", "'")
+
+    parts = text_to_process.split('%%', 1)
+    # Process text part first (which now has straight apostrophes)
+    text = parts[0].strip().replace('\"', '"') # Handle escaped quotes if any (though unlikely with straight apostrophes)
+
+    categories = []
+    if len(parts) > 1 and parts[1].strip():
+        raw_categories = parts[1].strip()
+        potential_categories = re.split(r'[\s,]+', raw_categories)
+        for cat in potential_categories:
+            cat_cleaned = cat.strip()
+            if cat_cleaned: 
+                categories.append(cat_cleaned)
+    
+    # Fallback for single '%' only if no categories found yet and '%%' was not in the original line
+    if not categories and '%' in parts[0] and '%%' not in text_to_process : # Check against text_to_process
+        # Reprocess parts[0] because it might contain the single '%'
+        # and ensure it also has apostrophes straightened
+        parts_single_percent_text = parts[0].replace("\u2019", "'").replace("’", "'")
+        parts_single_percent = parts_single_percent_text.split('%', 1)
+        text = parts_single_percent[0].strip().replace('\"', '"') # Update text if it was re-split
+        
+        if len(parts_single_percent) > 1 and parts_single_percent[1].strip():
+            raw_categories_single = parts_single_percent[1].strip()
+            potential_categories_single = re.split(r'[\s,]+', raw_categories_single)
+            for cat_s in potential_categories_single:
+                cat_s_cleaned = cat_s.strip()
+                if cat_s_cleaned:
+                    categories.append(cat_s_cleaned)
+
+    return {
+        "id": joke_id,
+        "text": text, 
+        "categories": sorted(list(set(c.capitalize() for c in categories if c))) 
+    }
+
+jokes = []
+joke_id_counter = 1
+
+# Process the multiline JOKE_DATA
+for line in JOKE_DATA.strip().split('\n'):
+    if len(line.strip()) < 3: 
+        continue
+    
+    # No need to process apostrophes here if parse_joke_line handles it for the whole line input
+    # processed_line = line.replace("\u2019", "'").replace("’", "'") # This was redundant
+
+    joke_data = parse_joke_line(line, joke_id_counter) # Pass original line, parse_joke_line does apostrophe replacement
+    if joke_data and joke_data['text']: 
+        jokes.append(joke_data)
+        joke_id_counter += 1
+
+# Write to jokes.json
+try:
+    with open('jokes.json', 'w', encoding='utf-8') as f:
+        json.dump(jokes, f, indent=4, ensure_ascii=False) 
+    print(f"Successfully created jokes.json with {len(jokes)} jokes, using straight apostrophes.")
+except Exception as e:
+    print(f"Error writing jokes.json: {e}")
+    try:
+        with open('jokes.json', 'w', encoding='utf-8') as f:
+            json.dump([], f, indent=4, ensure_ascii=False)
+        print("Wrote an empty list to jokes.json due to the error.")
+    except Exception as e_fallback:
+        print(f"Fallback write to jokes.json also failed: {e_fallback}")


### PR DESCRIPTION
- I regenerated jokes.json to use standard straight apostrophes (') instead of Unicode escape sequences (e.g., \u2019) for better raw file readability, as per your request.
- I ensured joke text and categories were preserved during this re-processing.
- The file contains 1517 jokes parsed from the text you provided.